### PR TITLE
added initial AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,4 +7,4 @@ Brian Wilson <brian@edx.org>
 Jay Zoldak <zoldak@edx.org>
 Christina Roberts <christina@edx.org>
 Will Daly <will@edx.org>
-James Tauber <jtauber@edx.org>
+James Tauber <jtauber@jtauber.com>


### PR DESCRIPTION
Per the contribution documentation I'm putting together, each repo should have an AUTHORS file, mostly for acknowledgement (especially of external contributors) but also to help track contributor agreements.

This is an auto-generated list from `git log --all` with dupes removed.
