### PR TITLE
Add default values for Boolean fields.

### DIFF
--- a/xblock/core.py
+++ b/xblock/core.py
@@ -233,11 +233,11 @@ class Float(ModelType):
 
 class Boolean(ModelType):
     """
-    A field class for representing a Boolean. This class has the values property predefined.
+    A field class for representing a Boolean. This class has the values property defined.
     """
-    def __init__(self, help=None, default=None, scope=Scope.content, display_name=None,
-                 values=({'display_name': "True", "value": True}, {'display_name': "False", "value": False})):
-        super( Boolean, self ).__init__(help, default, scope, display_name, values)
+    def __init__(self, help=None, default=None, scope=Scope.content, display_name=None):
+        super(Boolean, self).__init__(help, default, scope, display_name,
+            values=({'display_name': "True", "value": True}, {'display_name': "False", "value": False}))
 
 
 class Object(ModelType):

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -429,14 +429,14 @@ def test_values():
     # default if nothing specified
     assert_equals(None, String().values)
 
-    # Test boolean, which by default has values specified
+
+def test_values_boolean():
+    # Test Boolean, which has values defined
     test_field = Boolean()
     assert_equals(({'display_name': "True", "value": True}, {'display_name': "False", "value": False}), test_field.values)
 
-    # Test that you can override the Boolean default for values
-    test_field = Boolean(values=[False])
-    assert_equals([False], test_field.values)
 
-    # Test the format expected for integers
+def test_values_dict():
+    # Test that the format expected for integers is allowed
     test_field = Integer(values={"min": 1, "max" : 100})
     assert_equals({"min": 1, "max" : 100}, test_field.values)


### PR DESCRIPTION
Also increased documentation to give a hint as to how Studio uses values for selects (anything with a finite list of options), integers, floats.
