### PR TITLE
Be strict about ModelType expected types.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='XBlock',
-    version='0.1',
+    version='0.2',
     description='XBlock Core Library',
     packages=['xblock'],
     install_requires=[

--- a/xblock/problem.py
+++ b/xblock/problem.py
@@ -35,7 +35,7 @@ import random
 import string
 import time
 
-from .core import XBlock, Integer, Object, Scope, String, Any, Boolean
+from .core import XBlock, Integer, Scope, String, Any, Boolean, Dict
 from .run_script import run_script
 from .fragment import Fragment
 
@@ -242,7 +242,7 @@ class InputBlock(XBlock):
 @XBlock.tag("checker")
 class CheckerBlock(XBlock):
 
-    arguments = Object(help="The arguments expected by `check`")
+    arguments = Dict(help="The arguments expected by `check`")
 
     @classmethod
     def preprocess_input(cls, node, usage_factory):

--- a/xblock/test/test_model_types.py
+++ b/xblock/test/test_model_types.py
@@ -1,0 +1,208 @@
+"""
+Tests for classes extending ModelType.
+"""
+
+import unittest
+from xblock.core import *
+
+
+class ModelTypeTest(unittest.TestCase):
+    """ Base test class for ModelTypes. """
+    
+    def assertJSONEquals(self, expected, arg):
+        """
+        Asserts the result of field.from_json.
+        """
+        self.assertEqual(expected, self.test_field().from_json(arg))
+    
+    
+    def assertJSONValueError(self, arg):
+        """
+        Asserts that field.from_json throws a ValueError for the supplied value.
+        """
+        with self.assertRaises(ValueError):
+            self.test_field().from_json(arg)
+    
+    
+    def assertJSONTypeError(self, arg):
+        """
+        Asserts that field.from_json throws a TypeError for the supplied value.
+        """
+        with self.assertRaises(TypeError):
+            self.test_field().from_json(arg)
+    
+    
+class IntegerTest(ModelTypeTest):
+    """
+    Tests the Integer ModelType.
+    """
+    test_field = Integer
+
+    def test_integer(self):
+        self.assertJSONEquals(5, '5')
+        self.assertJSONEquals(0, '0')
+        self.assertJSONEquals(-1023, '-1023')
+        self.assertJSONEquals(7, 7)
+        self.assertJSONEquals(0, False)
+        self.assertJSONEquals(1, True)
+
+    def test_float_converts(self):
+        self.assertJSONEquals(1, 1.023)
+        self.assertJSONEquals(-3, -3.8)
+
+    def test_none(self):
+        self.assertJSONEquals(None, None)
+        self.assertJSONEquals(None, '')
+
+    def test_error(self):
+        self.assertJSONValueError('abc')
+        self.assertJSONValueError('[1]')
+        self.assertJSONValueError('1.023')
+
+        self.assertJSONTypeError([])
+        self.assertJSONTypeError({})
+
+
+class FloatTest(ModelTypeTest):
+    """
+    Tests the Float ModelType.
+    """
+    test_field = Float
+
+    def test_float(self):
+        self.assertJSONEquals(.23, '.23')
+        self.assertJSONEquals(5, '5')
+        self.assertJSONEquals(0, '0.0')
+        self.assertJSONEquals(-1023.22, '-1023.22')
+        self.assertJSONEquals(0, 0.0)
+        self.assertJSONEquals(4, 4)
+        self.assertJSONEquals(-0.23, -0.23)
+        self.assertJSONEquals(0, False)
+        self.assertJSONEquals(1, True)
+
+    def test_none(self):
+        self.assertJSONEquals(None, None)
+        self.assertJSONEquals(None, '')
+
+    def test_error(self):
+        self.assertJSONValueError('abc')
+        self.assertJSONValueError('[1]')
+
+        self.assertJSONTypeError([])
+        self.assertJSONTypeError({})
+
+
+class BooleanTest(ModelTypeTest):
+    """
+    Tests the Boolean ModelType.
+    """
+    test_field = Boolean
+
+    def test_false(self):
+        self.assertJSONEquals(False, "false")
+        self.assertJSONEquals(False, "False")
+        self.assertJSONEquals(False, "")
+        self.assertJSONEquals(False, "any other string")
+        self.assertJSONEquals(False, False)
+
+    def test_true(self):
+        self.assertJSONEquals(True, "true")
+        self.assertJSONEquals(True, "TruE")
+        self.assertJSONEquals(True, True)
+
+    def test_none(self):
+        self.assertJSONEquals(False, None)
+
+    def test_everything_converts_to_bool(self):
+        self.assertJSONEquals(True, 123)
+        self.assertJSONEquals(True, ['a'])
+        self.assertJSONEquals(False, [])
+
+
+class StringTest(ModelTypeTest):
+    """
+    Tests the String ModelType.
+    """
+    test_field = String
+
+    def test_json_equals(self):
+        self.assertJSONEquals("false", "false")
+        self.assertJSONEquals("abba", "abba")
+        self.assertJSONEquals('"abba"', '"abba"')
+        self.assertJSONEquals('', '')
+
+    def test_none(self):
+        self.assertJSONEquals(None, None)
+
+    def test_error(self):
+        self.assertJSONTypeError(['a'])
+        self.assertJSONTypeError(1.023)
+        self.assertJSONTypeError(3)
+        self.assertJSONTypeError([1])
+        self.assertJSONTypeError([])
+        self.assertJSONTypeError({})
+
+
+class AnyTest(ModelTypeTest):
+    """
+    Tests the Any ModelType.
+    """
+    test_field = Any
+
+    def test_json_equals(self):
+        self.assertJSONEquals({'bar'}, {'bar'})
+        self.assertJSONEquals("abba", "abba")
+        self.assertJSONEquals('', '')
+        self.assertJSONEquals('3.2', '3.2')
+        self.assertJSONEquals(False, False)
+        self.assertJSONEquals([3, 4], [3, 4])
+
+    def test_none(self):
+        self.assertJSONEquals(None, None)
+
+
+class ListTest(ModelTypeTest):
+    """
+    Tests the List ModelType.
+    """
+    test_field = List
+
+    def test_json_equals(self):
+        self.assertJSONEquals([], [])
+        self.assertJSONEquals(['foo', 'bar'], ['foo', 'bar'])
+        self.assertJSONEquals([1, 3.4], [1, 3.4])
+
+    def test_none(self):
+        self.assertJSONEquals(None, None)
+
+    def test_error(self):
+        self.assertJSONTypeError('abc')
+        self.assertJSONTypeError('')
+        self.assertJSONTypeError('1.23')
+        self.assertJSONTypeError('true')
+        self.assertJSONTypeError(3.7)
+        self.assertJSONTypeError(True)
+        self.assertJSONTypeError({})
+
+
+class DictTest(ModelTypeTest):
+    """
+    Tests the Dict ModelType.
+    """
+    test_field = Dict
+
+    def test_json_equals(self):
+        self.assertJSONEquals({}, {})
+        self.assertJSONEquals({'a' : 'b', 'c' : 3}, {'a' : 'b', 'c' : 3})
+
+    def test_none(self):
+        self.assertJSONEquals(None, None)
+
+    def test_error(self):
+        self.assertJSONTypeError(['foo', 'bar'])
+        self.assertJSONTypeError([])
+        self.assertJSONTypeError('abc')
+        self.assertJSONTypeError('1.23')
+        self.assertJSONTypeError('true')
+        self.assertJSONTypeError(3.7)
+        self.assertJSONTypeError(True)


### PR DESCRIPTION
This is a revised version of https://github.com/edx/XBlock/pull/27, with the serialize/deserialize code now living in edx-platform/xml_module, and strict error throwing in for_json methods.
