### PR TITLE
Ignore pylint warning R0921 - it's ok for us to provide abstract classes...

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -39,8 +39,9 @@ disable=
 # C0301: Line too long
 # W0141: Used builtin function 'map'
 # W0142: Used * or ** magic
+# R0921: Abstract class not referenced
 # R0922: Abstract class is only referenced 1 times
-    I0011,C0301,W0141,W0142,R0922,
+    I0011,C0301,W0141,W0142,R0921,R0922,
 
 # Django makes classes that trigger these
 # W0232: Class has no __init__ method


### PR DESCRIPTION
... without referencing them

@nedbat do you agree?
