### PR TITLE
Revert the naming of default view `context` argument

### DIFF
--- a/thumbs/thumbs.py
+++ b/thumbs/thumbs.py
@@ -24,10 +24,10 @@ class ThumbsBlock(InputBlock):
     downvotes = Integer(help="Number of down votes", default=0, scope=Scope.content)
     voted = Boolean(help="Has this student voted?", default=False, scope=Scope.user_state)
 
-    def student_view(self, _context):
+    def student_view(self, context):  # pylint: disable=W0613
         """
         Create a fragment used to display the XBlock to a student.
-        `_context` is a dictionary used to configure the display (unused)
+        `context` is a dictionary used to configure the display (unused)
 
         Returns a `Fragment` object specifying the HTML, CSS, and JavaScript
         to display.

--- a/workbench/blocks.py
+++ b/workbench/blocks.py
@@ -12,7 +12,7 @@ from .util import make_safe_for_html
 
 class DebuggingChildBlock(XBlock):
     """A simple gray box, to use as a child placeholder."""
-    def fallback_view(self, view_name, _context):
+    def fallback_view(self, view_name, context):  # pylint: disable=W0613
         """Provides a fallback view handler"""
         frag = Fragment(u"<div class='debug_child'>%s<br>%s</div>" % (make_safe_for_html(repr(self)), view_name))
         frag.add_css("""

--- a/workbench/runtime.py
+++ b/workbench/runtime.py
@@ -224,7 +224,7 @@ class WorkbenchRuntime(Runtime):
         template = django_template_loader.get_template(template_name)
         return template.render(DjangoContext(kwargs))
 
-    def wrap_child(self, block, frag, _context):
+    def wrap_child(self, block, frag, context):  # pylint: disable=W0613
         wrapped = Fragment()
         wrapped.add_javascript_url("/static/js/vendor/jquery.min.js")
         wrapped.add_javascript_url("/static/js/vendor/jquery.cookie.js")

--- a/workbench/test/test_views.py
+++ b/workbench/test/test_views.py
@@ -19,11 +19,11 @@ class TestMultipleViews(TestCase):
 
     class MultiViewXBlock(XBlock):
         """A bare-bone XBlock with two views."""
-        def student_view(self, _context):
+        def student_view(self, context):  # pylint: disable=W0613
             """A view, with the default name."""
             return Fragment(u"This is student view!")
 
-        def another_view(self, _context):
+        def another_view(self, context):  # pylint: disable=W0613
             """A secondary view for this block."""
             return Fragment(u"This is another view!")
 
@@ -48,7 +48,7 @@ class XBlockWithHandlerAndStudentState(XBlock):
     """A bare-bone XBlock with one view and one json handler."""
     the_data = String(default="def", scope=Scope.user_state)
 
-    def student_view(self, _context):
+    def student_view(self, context):  # pylint: disable=W0613
         """Provide the default view."""
         body = u"The data: %r." % self.the_data
         body += u":::%s:::" % self.runtime.handler_url("update_the_data")

--- a/xblock/content.py
+++ b/xblock/content.py
@@ -8,7 +8,7 @@ from .fragment import Fragment
 
 class HelloWorldBlock(XBlock):
     """A simple block: just show some fixed content."""
-    def fallback_view(self, _view_name, _context):
+    def fallback_view(self, _view_name, context):  # pylint: disable=W0613
         """Provide a fallback view handler"""
         return Fragment(u"Hello, world!")
 

--- a/xblock/problem.py
+++ b/xblock/problem.py
@@ -291,11 +291,11 @@ class TextInputBlock(InputBlock):
     input_type = String(help="Type of conversion to attempt on input string")
     student_input = String(help="Last input submitted by the student", default="", scope=Scope.user_state)
 
-    def student_view(self, _context):
+    def student_view(self, context):  # pylint: disable=W0613
         """Returns default student view."""
         return Fragment(u"<p>I can only appear inside problems.</p>")
 
-    def problem_view(self, _context):
+    def problem_view(self, context):  # pylint: disable=W0613
         """Returns a view of the problem - a javascript text input field."""
         html = u"<input type='text' name='input' value='{0}'><span class='message'></span>".format(self.student_input)
         result = Fragment(html)
@@ -415,7 +415,7 @@ class AttemptsScoreboardBlock(XBlock):
     Show attempts on problems in my nieces.
     """
 
-    def student_view(self, _context):
+    def student_view(self, context):  # pylint: disable=W0613
         """Provide default student view."""
         # Get the attempts for all problems in my parent.
         if self.parent:

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -262,7 +262,7 @@ class Runtime(object):
             results.append(result)
         return results
 
-    def wrap_child(self, _block, frag, _context):
+    def wrap_child(self, block, frag, context):  # pylint: disable=W0613
         """
         Wraps the fragment with any necessary HTML, informed by
         the block and the context. This default implementation

--- a/xblock/slider.py
+++ b/xblock/slider.py
@@ -16,7 +16,7 @@ class Slider(XBlock):
     max_value = Integer(help="Maximum value", default=100, scope=Scope.content)
     value = Integer(help="Student value", default=0, scope=Scope.user_state)
 
-    def student_view(self, _context):
+    def student_view(self, context):  # pylint: disable=W0613
         """Provide the default student view."""
         html = SLIDER_TEMPLATE.format(min=self.min_value,
                                       max=self.max_value,

--- a/xblock/view_counter.py
+++ b/xblock/view_counter.py
@@ -11,7 +11,7 @@ class ViewCounter(XBlock):
                     default=0,
                     scope=Scope.content)
 
-    def student_view(self, _context):
+    def student_view(self, context):  # pylint: disable=W0613
         """
         Render out the template.
 


### PR DESCRIPTION
@cpennington I was reading through your pull request on edx-platform and noticed in response to a request to change the unused argument `context` to `_context` you replied:

> If I do that, then I'm changing the signature from the standard for a view, which means that a call using a named argument view_fn(context=blarg) wouldn't work.

I realized I had done just this in my pep8/pylint cleanup on XBlock. This reverts that behavior.
