### PR TITLE
Provide metaclass that forces save after new XBlock initialization

### DIFF
--- a/xblock/core.py
+++ b/xblock/core.py
@@ -600,18 +600,30 @@ class TagCombiningMetaclass(type):
         return super(TagCombiningMetaclass, mcs).__new__(mcs, name, bases, attrs)
 
 
+class InitialSaveMetaclass(type):
+    """
+    Forces a `save` call after object is initialized.
+    """
+    def __call__(cls, *args, **kwargs):
+        # Call the base constructor, then after that completes, explicitly save
+        obj = type.__call__(cls, *args, **kwargs)
+        obj.save()
+        return obj
+
 class XBlockMetaclass(
         ChildrenModelMetaclass,
         NamespacesMetaclass,
         ModelMetaclass,
         TagCombiningMetaclass,
+        InitialSaveMetaclass,
 ):
     """
-    Metaclass that combines the four base XBlock metaclasses:
+    Metaclass that combines the five base XBlock metaclasses:
     * `ChildrenModelMetaclass`
     * `NamespacesMetaclass`
     * `ModelMetaclass`
     * `TagCombiningMetaclass`
+    * `InitialSaveMetaclass`
     """
     pass
 


### PR DESCRIPTION
@cpennington @ormsbee @dianakhuang 

MetaclassCount += 1

For local testing, check out branch `sarina/update-xblock-version` on edx-platform. I've tested and verified - this does fix the Lyla Problem. However, Cale, could you please explain more why this is the issue so we can decide whether or not this is the truly correct solution to the problem?
