### PR TITLE
Change the interface of DbModel to more closely match KeyValueStore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,5 +6,11 @@ These are notable changes in XBlock.  This is a rolling list of changes,
 in roughly chronological order, most recent first.  Add your entries at
 or near the top.  Include a label indicating the component affected.
 
-0.2
+0.3
 ----------
+
+* Changed the interface for `model_data` objects passed to `XBlocks` from
+  dict-like to the being cache-like (as was already used by `KeyValueStore`).
+  This removes the need to support methods like iteration and length, which
+  makes it easier to write new `ModelDatas`. Also added an actual `ModelData`
+  base class to serve as the expected interface.

--- a/doc/guide/xblock.rst
+++ b/doc/guide/xblock.rst
@@ -65,11 +65,11 @@ For convenience, we also provide five predefined scopes: ``Scope.content``,
 In XBlock code, state is accessed as attributes on self. In our example above,
 the data is available as ``self.upvotes``, ``self.downvotes``, and
 ``self.voted``.  The data is automatically scoped for the current user and
-block.  Modifications to the attributes are persisted implicitly, there is no
-save() method.  The runtime is free to provide these attributes however it
-likes.  For example, it could pre-load the data from a database, or proxy the
-attributes to load them lazily.  It could provide explicitly stored data, or it
-could provide calculated values as it sees fit.
+block.  Modifications to the attributes are stored in memory, and persisted to
+underlying ``ModelData`` instance when ``save()`` is called on the ``XBlock``.
+Runtimes should call ``save()`` after an ``XBlock`` is constructed, and after
+every invocation of a handler, view, or method on an XBlock. (The base ``Runtime`` class
+in ``xblock.runtime`` automatically calls ``save()`` after invoking views or handlers.)
 
 
 Children

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='XBlock',
-    version='0.2',
+    version='0.3',
     description='XBlock Core Library',
     packages=['xblock'],
     install_requires=[

--- a/workbench/runtime.py
+++ b/workbench/runtime.py
@@ -272,7 +272,7 @@ class WorkbenchRuntime(Runtime):
             self.student_id,
             self.usage
         )
-        value = data_model.get(key)
+        value = data_model.get(key, None)
         children = []
         for child_id in data_model.get('children', []):
             child = self.get_block(child_id)
@@ -294,7 +294,7 @@ class WorkbenchRuntime(Runtime):
             self.student_id,
             self.usage
         )
-        data[key] = value
+        data.set(key, value)
 
 
 class _BlockSet(object):

--- a/xblock/test/test_runtime.py
+++ b/xblock/test/test_runtime.py
@@ -131,7 +131,7 @@ def test_db_model_keys():
     db_model = DbModel(key_store, TestModel, 's0', TestUsage('u0', 'd0'))
     tester = TestModel(Mock(), db_model)
 
-    assert_false('not a field' in db_model)
+    assert_false(db_model.has('not a field'))
 
     # `test` is a namespace provided by the patch when TestModel is defined, which ultimately
     # comes from the NamespacesMetaclass. Since this is not understood by static
@@ -140,7 +140,7 @@ def test_db_model_keys():
     for collection in (tester, tester.test):
         for field in collection.fields:
             new_value = 'new ' + field.name
-            assert_false(field.name in db_model)
+            assert_false(db_model.has(field.name))
             setattr(collection, field.name, new_value)
 
     # Write out the values
@@ -149,7 +149,7 @@ def test_db_model_keys():
     # Make sure everything saved correctly
     for collection in (tester, tester.test):
         for field in collection.fields:
-            assert_true(field.name in db_model)
+            assert_true(db_model.has(field.name))
 
     def get_key_value(scope, student_id, block_scope_id, field_name):
         """Gets the value, from `key_store`, of a Key with the given values."""

--- a/xblock/test/test_timedelta.py
+++ b/xblock/test/test_timedelta.py
@@ -10,6 +10,7 @@ from nose.tools import assert_equals, assert_not_equals, assert_not_in  # pylint
 
 import re
 from xblock.core import ModelType, Scope, XBlock
+from xblock.test.test_core import DictModel
 import datetime
 
 TIMEDELTA_REGEX = re.compile(r'^((?P<days>\d+?) day(?:s?))?(\s)?((?P<hours>\d+?) hour(?:s?))?(\s)?((?P<minutes>\d+?) minute(?:s)?)?(\s)?((?P<seconds>\d+?) second(?:s)?)?$')
@@ -60,7 +61,7 @@ def test_timedelta_field_access():
         graceperiod = Timedelta(scope=Scope.settings)
 
     original_json_date = '2 days 5 hours 10 minutes 59 seconds'
-    field_tester = FieldTester(MagicMock(), {'graceperiod': original_json_date})
+    field_tester = FieldTester(MagicMock(), DictModel({'graceperiod': original_json_date}))
 
     # Access the Timedelta field without modifying it
 


### PR DESCRIPTION
This means we don't have to support all of the methods in dicts without
when we don't have the same support for those methods in the underlying
storage.

[LMS-826]

@dianakhuang @nedbat: Review?
