### PR TITLE
DO NOT MERGE: Change pylint settings to not report on importing assert_* from nose.tools

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -99,6 +99,11 @@ ignore-mixin-members=yes
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
 
+# See http://stackoverflow.com/questions/17156240/nose-tools-and-pylint
+# Pylint does not like the way that nose tools inspects and makes available
+# the assert classes
+ignored-classes=nose.tools,nose.tools.trivial
+
 # When zope mode is activated, add a predefined set of Zope acquired attributes
 # to generated-members.
 zope=no


### PR DESCRIPTION
@sarina @wedaly.

hrm, this didn't seem to work in edx-platform. looking into the syntax.
