### PR TITLE
More user scopes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ or near the top.  Include a label indicating the component affected.
 
 0.3
 ----------
+* Change the user field of Scopes to be three valued, rather than two.
+  False is now UserScope.NONE, True is UserScope.ONE, and UserScope.ALL is new,
+  and represents data that is computed based on input from many users.
+
 * Rename ModelData to FieldData
 
 * Rename ModelType to Field

--- a/thumbs/thumbs.py
+++ b/thumbs/thumbs.py
@@ -21,8 +21,8 @@ class ThumbsBlock(InputBlock):
 
     """
 
-    upvotes = Integer(help="Number of up votes", default=0, scope=Scope.content)
-    downvotes = Integer(help="Number of down votes", default=0, scope=Scope.content)
+    upvotes = Integer(help="Number of up votes", default=0, scope=Scope.user_state_summary)
+    downvotes = Integer(help="Number of down votes", default=0, scope=Scope.user_state_summary)
     voted = Boolean(help="Has this student voted?", default=False, scope=Scope.user_state)
 
     def student_view(self, context):  # pylint: disable=W0613

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -95,6 +95,21 @@ class BlockScope(object):
     USAGE, DEFINITION, TYPE, ALL = xrange(4)
 
 
+class UserScope(object):
+    """
+    Enumeration of valid UserScopes
+
+    NONE: This scope identifies data agnostic to the user of the xblock
+        For instance, the definition of a randomized problem
+    ONE: This scope identifies data supplied by a single user of the xblock
+        For instance, a students answer to a randomized problem
+    ALL: This scope identifies data aggregated while the block is used
+        by many users.
+        For instance, a histogram of the answers submitted by all students
+    """
+    NONE, ONE, ALL = xrange(3)
+
+
 class Sentinel(object):
     """
     Class for implementing sentinel objects (only equal to themselves).
@@ -115,8 +130,8 @@ ScopeBase = namedtuple('ScopeBase', 'user block')  # pylint: disable=C0103
 
 class Scope(ScopeBase):
     """
-    Defines five types of Scopes to be used: `content`, `settings`,
-    `user_state`, `preferences`, and `user_info`.
+    Defines six types of Scopes to be used: `content`, `settings`,
+    `user_state`, `preferences`, `user_info`, and `user_state_summary`.
 
     The `content` scope is used to save data for all users, for one particular
     block, across all runs of a course. An example might be an XBlock that
@@ -138,13 +153,18 @@ class Scope(ScopeBase):
     The `user_info` scope is used to save data for one user, across the entire platform. An
     example might be a user's time zone or language preference.
 
+    The `user_state_summary` scope is used to save data aggregated across many users of a
+    single block. For example, a block might store a histogram of the points scored by all
+    users attempting a problem.
+
     """
 
-    content = ScopeBase(user=False, block=BlockScope.DEFINITION)
-    settings = ScopeBase(user=False, block=BlockScope.USAGE)
-    user_state = ScopeBase(user=True, block=BlockScope.USAGE)
-    preferences = ScopeBase(user=True, block=BlockScope.TYPE)
-    user_info = ScopeBase(user=True, block=BlockScope.ALL)
+    content = ScopeBase(user=UserScope.NONE, block=BlockScope.DEFINITION)
+    settings = ScopeBase(user=UserScope.NONE, block=BlockScope.USAGE)
+    user_state = ScopeBase(user=UserScope.ONE, block=BlockScope.USAGE)
+    preferences = ScopeBase(user=UserScope.ONE, block=BlockScope.TYPE)
+    user_info = ScopeBase(user=UserScope.ONE, block=BlockScope.ALL)
+    user_state_summary = ScopeBase(user=UserScope.ALL, block=BlockScope.USAGE)
 
     children = Sentinel('Scope.children')
     parent = Sentinel('Scope.parent')

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -6,7 +6,7 @@ import re
 import functools
 
 from collections import namedtuple, MutableMapping
-from xblock.fields import Field, BlockScope, Scope, FieldData, UNSET
+from xblock.fields import Field, BlockScope, Scope, FieldData, UNSET, UserScope
 from xblock.exceptions import NoSuchViewError, NoSuchHandlerError
 from xblock.core import XBlock
 
@@ -114,7 +114,7 @@ class DbModel(FieldData):
             elif block_scope == BlockScope.TYPE:
                 block_id = block.scope_ids.block_type
 
-            if field.scope.user:
+            if field.scope.user == UserScope.ONE:
                 student_id = block.scope_ids.student_id
             else:
                 student_id = None


### PR DESCRIPTION
Change user scoping from `True`/`False` to `NONE`/`ONE`/`ALL`, to more succinctly capture the scope of the data that (for instance) the `Thumbs` module stores.

@nedbat @sarina: Review?
