### PR TITLE
Fix bug in which an HTML block with only text body was not being loaded ...

### DIFF
--- a/xblock/content.py
+++ b/xblock/content.py
@@ -40,7 +40,7 @@ class HtmlBlock(XBlock):
         """
         block = runtime.construct_xblock_from_class(cls, keys)
 
-        block.content = node.text or u""
+        block.content = unicode(node.text or u"")
         for child in node:
             block.content += etree.tostring(child, encoding='unicode')
 

--- a/xblock/test/test_parsing.py
+++ b/xblock/test/test_parsing.py
@@ -196,3 +196,8 @@ class HtmlInOutTest(XmlTest, unittest.TestCase):
             xml = self.export_xml_for_block(block)
 
             self.assertIn(test, xml)
+
+    def test_text_is_unicode(self):
+        the_xml = "<html>Hello, world</html>"
+        block = self.parse_xml_to_block(the_xml)
+        self.assertTrue(isinstance(block.content, unicode))


### PR DESCRIPTION
...as unicode, and so was failing assert in Fragment.
