### PR TITLE
Fix test isolation problems

### DIFF
--- a/workbench/runtime.py
+++ b/workbench/runtime.py
@@ -97,6 +97,11 @@ class MemoryUsageStore(UsageStore):
         """Generate a new id."""
         return str(next(self._ids))
 
+    def clear(self):
+        """Remove all entries."""
+        self._usages.clear()
+        self._definitions.clear()
+
     def create_usage(self, def_id):
         """Make a usage, storing its definition id."""
         usage_id = self._next_id()
@@ -256,3 +261,17 @@ MEMORY_KVS = MemoryKeyValueStore({})
 
 # Our global usage store
 USAGE_STORE = MemoryUsageStore()
+
+
+def reset_global_state():
+    """
+    Reset any global state in the workbench.
+
+    This allows us to write properly isolated tests.
+
+    """
+    from .scenarios import init_scenarios       # avoid circularity.
+
+    MEMORY_KVS.clear()
+    USAGE_STORE.clear()
+    init_scenarios()

--- a/workbench/scenarios.py
+++ b/workbench/scenarios.py
@@ -45,13 +45,13 @@ def add_class_scenarios(class_name, cls):
             add_xml_scenario(scname, desc, xml)
 
 
-def _do_once():
+def init_scenarios():
     """
-    Called once when the module is imported to create the global scenarios.
+    Create all the scenarios declared in all the XBlock classes.
     """
+    # Clear any existing scenarios, since this is used repeatedly during testing.
+    SCENARIOS.clear()
+
     # Get all the XBlock classes, and add their scenarios.
     for class_name, cls in XBlock.load_classes():
         add_class_scenarios(class_name, cls)
-
-
-_do_once()

--- a/workbench/test/selenium_test.py
+++ b/workbench/test/selenium_test.py
@@ -5,7 +5,7 @@ from selenium import webdriver
 
 from nose.plugins.attrib import attr
 
-from workbench.runtime import MEMORY_KVS
+from workbench.runtime import reset_global_state
 
 
 @attr('selenium')
@@ -27,5 +27,6 @@ class SeleniumTest(LiveServerTestCase):
     def setUp(self):
         super(SeleniumTest, self).setUp()
 
-        # Clear the in-memory key value store
-        MEMORY_KVS.clear()
+        # Clear the in-memory key value store, the usage store, and whatever
+        # else needs to be cleared and re-initialized.
+        reset_global_state()

--- a/workbench/test/test_scenarios.py
+++ b/workbench/test/test_scenarios.py
@@ -4,6 +4,9 @@ import lxml.html
 
 from django.test.client import Client
 
+from xblock.core import XBlock
+from xblock.test.tools import assert_equals
+
 
 def test_all_scenarios():
     """Load the home page, get every URL, make a test from it."""
@@ -11,8 +14,29 @@ def test_all_scenarios():
     response = client.get("/")
     assert response.status_code == 200
     html = lxml.html.fromstring(response.content)
-    for a_tag in html.xpath('//a'):
+    a_tags = list(html.xpath('//a'))
+    for a_tag in a_tags:
         yield try_scenario, a_tag.get('href'), a_tag.text
+
+    # Load the scenarios from the classes.
+    scenarios = []
+    for _, cls in XBlock.load_classes():
+        if hasattr(cls, "workbench_scenarios"):
+            for _, xml in cls.workbench_scenarios():
+                scenarios.append(xml)
+
+    # We should have an <a> tag for each scenario.
+    assert_equals(len(a_tags), len(scenarios))
+
+    # We should have at least one scenario with a vertical tag, since we use
+    # empty verticals as our canary in the coal mine that something has gone
+    # horribly wrong with loading the scenarios.
+    assert any("<vertical>" in xml for xml in scenarios)
+
+    # Since we are claiming in try_scenario that no vertical is empty, let's
+    # eliminate the possibility that a scenario has an actual empty vertical.
+    assert all("<vertical></vertical>" not in xml for xml in scenarios)
+    assert all("<vertical/>" not in xml for xml in scenarios)
 
 
 def try_scenario(url, name):
@@ -23,6 +47,18 @@ def try_scenario(url, name):
     `name`: the name of the scenario, used in error messages.
 
     """
+    # This is a very shallow test.  We don't know enough about each scenario to
+    # know what each should do.  So we load the scenario to see that the
+    # workbench could successfully serve it.
     client = Client()
     response = client.get(url, follow=True)
     assert response.status_code == 200, name
+
+    # Be sure we got the whole scenario.  Again, we can't know what to expect
+    # here, but at the very least, if there are verticals, they should not be
+    # empty.  That would be a sign that some data wasn't loaded properly while
+    # rendering the scenario.
+    html = lxml.html.fromstring(response.content)
+    for vertical_tag in html.xpath('//div[@class="vertical"]'):
+        # No vertical tag should be empty.
+        assert list(vertical_tag), "Empty <vertical> shouldn't happen!"

--- a/workbench/urls.py
+++ b/workbench/urls.py
@@ -6,8 +6,10 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 # This import is here simply to get this file imported explicitly.
 # If it fails to import later, it's inside the url resolver, and we
 # don't see the actual errors.
-from workbench.scenarios import SCENARIOS       # pylint: disable=W0611
+from workbench.scenarios import init_scenarios
 
+
+init_scenarios()
 
 urlpatterns = patterns(
     'workbench.views',


### PR DESCRIPTION
Turns out our tests weren't testing as much as we thought, because the
Selenium tests clobbered the key-value store, but the scenarios and
usage store survived, so when we loaded scenarios, the definition ids
wouldn't be in the KVS, so they'd get only default values, and no
children.

I've added tests that check for that failure condition, and also
systematically reset all three components (KVS, usage store, and
scenarios) together, so they will be correct for all tests.
