### PR TITLE
Require a @XBlock.handler on handler methods.

### DIFF
--- a/xblock/core.py
+++ b/xblock/core.py
@@ -82,6 +82,7 @@ class XBlock(Plugin):
         will be JSON-encoded and returned as the response.
 
         """
+        @XBlock.handler
         @functools.wraps(func)
         def wrapper(self, request, suffix=''):
             """The wrapper function `json_handler` returns."""
@@ -89,6 +90,11 @@ class XBlock(Plugin):
             response_json = json.dumps(func(self, request_json, suffix))
             return Response(response_json, content_type='application/json')
         return wrapper
+
+    @classmethod
+    def handler(cls, func):
+        func._is_xblock_handler = True
+        return func
 
     @classmethod
     def tag(cls, tags):

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -413,12 +413,12 @@ class Runtime(object):
         :param suffix: The remainder of the url, after the handler url prefix, if available
         """
         handler = getattr(block, handler_name, None)
-        if handler:
+        if handler and getattr(handler, '_is_xblock_handler', False):
             # Cache results of the handler call for later saving
             results = handler(request, suffix)
         else:
             fallback_handler = getattr(block, "fallback_handler", None)
-            if fallback_handler:
+            if fallback_handler and getattr(fallback_handler, '_is_xblock_handler', False):
                 # Cache results of the handler call for later saving
                 results = fallback_handler(handler_name, request, suffix)
             else:


### PR DESCRIPTION
Enhanced security by requiring that all XBlock handlers have a explicit decorator. This can be either the existing @XBlock.json_handler or else a new @XBlock.handler decorator.
