### PR TITLE
Put the plugin cache at the module level

### DIFF
--- a/xblock/test/test_plugin.py
+++ b/xblock/test/test_plugin.py
@@ -74,17 +74,21 @@ def test_broken_plugin():
     plugins = XBlock.load_classes()
     assert_equals(list(plugins), [])
 
-def num_plugins_cached():
-    """Returns the number of plugins that have been cached."""
-    return len(plugin._plugin_cache.keys())
+
+def _num_plugins_cached():
+    """
+    Returns the number of plugins that have been cached.
+    """
+    return len(plugin.PLUGIN_CACHE.keys())
+
 
 @XBlock.register_temp_plugin(AmbiguousBlock1, "thumbs")
 def test_plugin_caching():
-    plugin._plugin_cache = {}
-    assert_equals(num_plugins_cached(), 0)
+    plugin.PLUGIN_CACHE = {}
+    assert_equals(_num_plugins_cached(), 0)
 
     XBlock.load_class("thumbs")
-    assert_equals(num_plugins_cached(), 1)
+    assert_equals(_num_plugins_cached(), 1)
 
     XBlock.load_class("thumbs")
-    assert_equals(num_plugins_cached(), 1)
+    assert_equals(_num_plugins_cached(), 1)


### PR DESCRIPTION
@cpennington 

Put the plugin cache at the module level and add test for correct operation.

The motivation for this change is that the current behavior of the plugin cache is confusing, subtle and may not perform as intended. Example:

Before the very first call to load_class
  `Plugin._plugin_cache == None`
  `XBlock._plugin_cache undefined`

Then a call is made to `XBlock.load_class('my_block')`. In `load_class`, `cls` is `XBlock` and so:
  `Plugin._plugin_cache == None`
  `XBlock._plugin_cache == { .. cached plugin .. }`

Also, potentially a call could be made from somewhere to MyXBlock.load_class('my_block'). At that point we have:
  `Plugin._plugin_cache == None`
  `XBlock._plugin_cache == { .. cached plugin 1 .. }`
  `MyXBlock._plugin_cache == { .. cached plugin 2 .. }`

As a result of this change, there will be a single plugin cache which holds all the cached plugins, and belongs to xblock.plugin.
