### PR TITLE
Useful link right out github

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ as the default does.
 Documentation
 -------------
 
-The docs for the XBlock API is on Read The Docs:  https://xblock.readthedocs.org .
+The docs for the XBlock API is on Read The Docs:  https://xblock.readthedocs.org . Information on how to integrate XBlocks with the edx platform are sourced from https://github.com/edx/edx-platform/blob/master/docs/en_us/developers/source/xblocks.rst#deploying-your-xblock
 
 
 


### PR DESCRIPTION
This links is already included in the readthedocs, but is useful to have right out of github.
