### PR TITLE
Django Model backed XBlock state storage

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -7,5 +7,4 @@ if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "workbench.settings")
 
     from django.core.management import execute_from_command_line
-
     execute_from_command_line(sys.argv)

--- a/workbench/admin.py
+++ b/workbench/admin.py
@@ -1,0 +1,24 @@
+"""
+Basic admin screens for displaying XBlock state and filtering/searching on the
+fields.
+"""
+from django.contrib import admin
+from .models import XBlockState
+
+
+class XBlockStateAdmin(admin.ModelAdmin):
+    """Basic admin operations for XBlockState model.
+
+    This is primarily meant for viewing/filtering/searching, not for editing.
+    You're only allowed to edit the state fields themselves, not the IDs or
+    categories. Since things like `tag` and `scenario` are set on write, weird
+    things could happen if you muck with them later on.
+    """
+    list_display = ['scope_id', 'scope', 'user_id', 'state']
+    list_filter = ['scope', 'user_id', 'scenario', 'tag']
+    search_fields = ['user_id', 'scope_id', 'state']
+    readonly_fields = [
+        'scope', 'scope_id', 'scenario', 'tag', 'user_id', 'created'
+    ]
+
+admin.site.register(XBlockState, XBlockStateAdmin)

--- a/workbench/models.py
+++ b/workbench/models.py
@@ -1,0 +1,108 @@
+"""
+XBlock persistent state storage.
+
+We use a Django model to store state in all our various scopes in one table. We
+make no effort to be smart about batch updates, so performance isn't great. We
+mostly use Django because we already have it as a dependency and because Django
+Admin gives us a lot of basic search/filtering for free.
+
+"""
+from django.db import models
+from django.utils.timezone import now
+
+from xblock.fields import BlockScope, Scope
+
+
+def shorten_scope_name(scope_name):
+    """Strip the "blockscope_" or "scope_" prefixes from scope names."""
+    _prefix, rest = scope_name.split("_", 1)
+    return rest
+
+
+class XBlockState(models.Model):
+    """State storage for XBlock.
+
+    This class assumes your IDs were generated using `ScenarioIdManager`, and
+    will break otherwise.
+
+    """
+    BLOCK_SCOPE_NAMES = [
+        (shorten_scope_name(sentinel.attr_name), shorten_scope_name(sentinel.attr_name))
+        for sentinel in BlockScope.scopes() + [Scope.parent, Scope.children]
+    ]
+
+    # Either the block scope or the special scopes "children" or "parent"
+    scope = models.CharField(
+        max_length=50,
+        blank=True,
+        null=True,
+        db_index=True,
+        choices=BLOCK_SCOPE_NAMES
+    )
+    scope_id = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        db_index=True,
+        verbose_name="Scope ID",
+    )
+    user_id = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        db_index=True,
+        verbose_name="User ID",
+    )
+    scenario = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        db_index=True,
+    )
+    tag = models.CharField(
+        max_length=50,
+        blank=True,
+        null=True,
+        db_index=True,
+    )
+    created = models.DateTimeField(default=now, db_index=True)
+    state = models.TextField(default="{}")
+
+    @classmethod
+    def get_for_key(cls, key):
+        """Get or create the model row for a given `KeyValueStore.Key` `key`."""
+        if key.scope in [Scope.parent, Scope.children]:
+            block_scope_full_name = key.scope.attr_name
+        else:
+            block_scope_full_name = key.scope.block.attr_name
+        block_scope_name = shorten_scope_name(block_scope_full_name)
+        scope_id = key.block_scope_id
+
+        # Ask our ID Manager for how this scope_id maps to scenario and XML tag
+        scenario, tag, _ = scope_id.split(".", 2)
+        record, _ = cls.objects.get_or_create(
+            scope=block_scope_name,
+            scope_id=key.block_scope_id,
+            user_id=key.user_id,
+            scenario=scenario,
+            tag=tag,
+        )
+        return record
+
+    @classmethod
+    def prep_for_scenario_loading(cls):
+        """This method should be executed once before loading scenarios.
+
+        For the most part, when scenarios load, they just overwrite their
+        previous entries. But adding children is an append operation, so we just
+        delete all the children scoped entries in this method.
+
+        Note that this should be called *once* before any scenario loading
+        happens. It should *not* be called before each scenario.
+        """
+        cls.objects.filter(scope="children").delete()
+
+    class Meta:  # pylint:disable=C0111
+        verbose_name = "XBlock State"
+        verbose_name_plural = "XBlock State"
+        ordering = ['scope_id', 'scope', 'user_id']

--- a/workbench/scenarios.py
+++ b/workbench/scenarios.py
@@ -3,16 +3,17 @@
 This code is in the Workbench layer.
 
 """
-
 from collections import namedtuple
 
-from xblock.core import XBlock
+from django.conf import settings
+from django.template.defaultfilters import slugify
 
-from .runtime import WorkbenchRuntime
+from xblock.core import XBlock
+from .runtime import WorkbenchRuntime, WORKBENCH_KVS
 
 # Build the scenarios, which are named trees of usages.
 
-Scenario = namedtuple("Scenario", "description usage_id")  # pylint: disable=C0103
+Scenario = namedtuple("Scenario", "description usage_id xml")  # pylint: disable=C0103
 
 SCENARIOS = {}
 
@@ -27,8 +28,9 @@ def add_xml_scenario(scname, description, xml):
     # WorkbenchRuntime has an id_generator, but most runtimes won't
     # (because the generator will be contextual), so we
     # pass it explicitly to parse_xml_string.
+    runtime.id_generator.set_scenario(slugify(description))
     usage_id = runtime.parse_xml_string(xml, runtime.id_generator)
-    SCENARIOS[scname] = Scenario(description, usage_id)
+    SCENARIOS[scname] = Scenario(description, usage_id, xml)
 
 
 def remove_scenario(scname):
@@ -55,7 +57,11 @@ def init_scenarios():
     """
     # Clear any existing scenarios, since this is used repeatedly during testing.
     SCENARIOS.clear()
+    if settings.WORKBENCH['reset_state_on_restart']:
+        WORKBENCH_KVS.clear()
+    else:
+        WORKBENCH_KVS.prep_for_scenario_loading()
 
     # Get all the XBlock classes, and add their scenarios.
-    for class_name, cls in XBlock.load_classes():
+    for class_name, cls in sorted(XBlock.load_classes()):
         add_class_scenarios(class_name, cls)

--- a/workbench/settings.py
+++ b/workbench/settings.py
@@ -1,4 +1,6 @@
 """Django settings for workbench project."""
+import json
+import os
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
@@ -12,16 +14,15 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': ':memory:',                      # Or path to database file if using sqlite3.
-        'USER': '',                      # Not used with sqlite3.
-        'PASSWORD': '',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
+if 'WORKBENCH_DATABASES' in os.environ:
+    DATABASES = json.loads(os.environ['WORKBENCH_DATABASES'])
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': 'workbench.db'
+        }
     }
-}
 
 CACHES = {
     'default': {
@@ -34,7 +35,7 @@ CACHES = {
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
 # In a Windows environment this must be set to your system time zone.
-TIME_ZONE = 'America/Chicago'
+TIME_ZONE = 'America/New_York'
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
@@ -121,13 +122,14 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'workbench',
     'django_nose',
+
     # Uncomment the next line to enable the admin:
-    # 'django.contrib.admin',
+    'django.contrib.admin',
+
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
 )
@@ -160,5 +162,14 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': True,
         },
+        'django': {
+            'level': 'INFO',
+        }
     }
+}
+
+WORKBENCH = {
+    'reset_state_on_restart': (
+        os.environ.get('WORKBENCH_RESET_STATE_ON_RESTART', "false").lower() == "true"
+    )
 }

--- a/workbench/templates/workbench/block.html
+++ b/workbench/templates/workbench/block.html
@@ -27,21 +27,35 @@
 
                 <section class="debug">
                     <div class="data">
-                        <span class="label">Log</span>
-
-                        {{log|safe}}
-                    </div>
-
-                    <div class="data">
                         <span class="label">Database</span>
-
-                        {{database.as_html|safe}}
+                        <div align="left" style="float:left">
+                            <a href="{% url admin:workbench_xblockstate_changelist %}?scenario={{scenario.description|slugify}}"
+                            >Scenario State</a>
+                        </div>
+                        <div align="right">
+                            <form method="POST" action="{% url workbench.views.reset_state %}">
+                                <input type="submit" value="Reset State"/>
+                            </form>
+                        </div>
                     </div>
-
                     <div class="data">
                         <span class="label">Block</span>
-
                         {{block}}
+                    </div>
+                    <div class="data">
+                        <span class="label">Scenario</span>
+                        <pre>{{scenario.xml}}</pre>
+                    </div>
+                    <div class="data">
+                        <span class="label">Log</span>
+                        <div id="workbench_log" style="max-height: 300px; overflow-y: scroll;">
+                            <pre>{{log}}</pre>
+                        </div>
+                        <!-- Temporary expedient before log gets moved out -->
+                        <script type="text/javascript">
+                            // Scroll the Workbench Log to the bottom of the div...
+                            $('#workbench_log').scrollTop($('#workbench_log')[0].scrollHeight);
+                        </script>
                     </div>
                 </section>
             </div>

--- a/workbench/templates/workbench/index.html
+++ b/workbench/templates/workbench/index.html
@@ -18,5 +18,10 @@
                 </section>
             </div>
         </div>
+        <div>
+            <form method="POST" action="{% url workbench.views.reset_state %}">
+                <input type="submit" value="Reset State"/>
+            </form>
+        </div>
     </body>
 </body>

--- a/workbench/test/test_runtime.py
+++ b/workbench/test/test_runtime.py
@@ -1,0 +1,66 @@
+"""Test Workbench Runtime"""
+
+from xblock.test.tools import assert_equals, assert_false, assert_is_none, assert_true
+
+from xblock.fields import Scope
+from xblock.runtime import KeyValueStore
+from ..runtime import ScenarioIdManager, WorkbenchDjangoKeyValueStore
+
+
+def test_scenario_ids():
+    # Test basic ID generation meets our expectations
+    id_mgr = ScenarioIdManager()
+
+    # No scenario loaded
+    assert_equals(id_mgr.create_definition("my_block"), ".my_block.d0")
+    # Should increment
+    assert_equals(id_mgr.create_definition("my_block"), ".my_block.d1")
+    assert_equals(id_mgr.create_definition("my_block"), ".my_block.d2")
+
+    # Slug support
+    assert_equals(
+        id_mgr.create_definition("my_block", "my_slug"),
+        ".my_block.my_slug.d0"
+    )
+    assert_equals(
+        id_mgr.create_definition("my_block", "my_slug"),
+        ".my_block.my_slug.d1"
+    )
+
+    # Now that we have a scenario, our definition numbering starts over again.
+    id_mgr.set_scenario("my_scenario")
+    assert_equals(id_mgr.create_definition("my_block"), "my_scenario.my_block.d0")
+    assert_equals(id_mgr.create_definition("my_block"), "my_scenario.my_block.d1")
+
+    id_mgr.set_scenario("another_scenario")
+    assert_equals(id_mgr.create_definition("my_block"), "another_scenario.my_block.d0")
+
+    # Now make sure our usages are attached to definitions
+    assert_is_none(id_mgr.last_created_usage_id())
+    assert_equals(
+        id_mgr.create_usage("my_scenario.my_block.d0"),
+        "my_scenario.my_block.d0.u0"
+    )
+    assert_equals(
+        id_mgr.create_usage("my_scenario.my_block.d0"),
+        "my_scenario.my_block.d0.u1"
+    )
+    assert_equals(id_mgr.last_created_usage_id(), "my_scenario.my_block.d0.u1")
+
+
+def test_kv_store():
+    # Simple test to makes sure we can get things in and out
+    kvs = WorkbenchDjangoKeyValueStore()
+    key = KeyValueStore.Key(
+        scope=Scope.content,
+        user_id="rusty",
+        block_scope_id="my_scenario.my_block.d0",
+        field_name="age"
+    )
+
+    assert_false(kvs.has(key))
+    kvs.set(key, 7)
+    assert_true(kvs.has(key))
+    assert_equals(kvs.get(key), 7)
+    kvs.delete(key)
+    assert_false(kvs.has(key))

--- a/workbench/test/test_views.py
+++ b/workbench/test/test_views.py
@@ -27,7 +27,7 @@ def temp_scenario(temp_class, scenario_name='test_scenario'):
         def _inner(*args, **kwargs):                    # pylint: disable=C0111
             # Create a scenario, just one tag for our mocked class.
             scenarios.add_xml_scenario(
-                scenario_name, "Temporary scenario",
+                scenario_name, "Temporary scenario {}".format(temp_class.__name__),
                 "<%s/>" % temp_class.__name__
             )
             try:
@@ -120,10 +120,9 @@ def test_xblock_without_handler():
     # when we try to hit a handler on it
     client = Client()
 
-    # Pick a random usage_id from the ID_MANAGER because we
-    # need to ensure the usage is a valid id.
-    # TODO: Make a usage in this test instead.
-    usage_id = ID_MANAGER._usages.keys()[0]
+    # Pick the most usage ID we just made in the temp_scenario setup...
+    usage_id = ID_MANAGER.last_created_usage_id()
+
     # Plug that usage_id into a mock handler URL
     # /handler/[usage_id]/[handler_name]
     handler_url = reverse('handler', kwargs={

--- a/workbench/urls.py
+++ b/workbench/urls.py
@@ -1,22 +1,38 @@
 """Provide XBlock urls"""
 
-from django.conf.urls import patterns, url
+from django.conf.urls import include, patterns, url
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.contrib import admin
 
 from workbench.scenarios import init_scenarios
 
+admin.autodiscover()
 
 init_scenarios()
 
 urlpatterns = patterns(
     'workbench.views',
     url(r'^$', 'index', name='workbench_index'),
-    url(r'^scenario/(?P<scenario_id>[^/]+)/(?P<view_name>[^/]+)/$', 'show_scenario', name='scenario'),
-    url(r'^scenario/(?P<scenario_id>[^/]+)/$', 'show_scenario', name='workbench_show_scenario'),
-
-    url(r'^view/(?P<scenario_id>[^/]+)/(?P<view_name>[^/]+)/$', 'show_scenario', {'template': 'workbench/blockview.html'}),
-    url(r'^view/(?P<scenario_id>[^/]+)/$', 'show_scenario', {'template': 'workbench/blockview.html'}),
-
+    url(
+        r'^scenario/(?P<scenario_id>[^/]+)/(?P<view_name>[^/]+)/$',
+        'show_scenario',
+        name='scenario'
+    ),
+    url(
+        r'^scenario/(?P<scenario_id>[^/]+)/$',
+        'show_scenario',
+        name='workbench_show_scenario'
+    ),
+    url(
+        r'^view/(?P<scenario_id>[^/]+)/(?P<view_name>[^/]+)/$',
+        'show_scenario',
+        {'template': 'workbench/blockview.html'}
+    ),
+    url(
+        r'^view/(?P<scenario_id>[^/]+)/$',
+        'show_scenario',
+        {'template': 'workbench/blockview.html'}
+    ),
     url(
         r'^handler/(?P<usage_id>[^/]+)/(?P<handler_slug>[^/]*)(?:/(?P<suffix>.*))?$',
         'handler', {'authenticated': True},
@@ -32,6 +48,13 @@ urlpatterns = patterns(
         'package_resource',
         name='package_resource'
     ),
+    url(
+        r'^reset_state$',
+        'reset_state',
+        name='reset_state'
+    ),
+
+    url(r'^admin/', include(admin.site.urls)),
 )
 
 urlpatterns += staticfiles_urlpatterns()

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -191,7 +191,6 @@ class Scope(ScopeBase):
         return isinstance(other, Scope) and self.user == other.user and self.block == other.block
 
 
-
 ScopeIds = namedtuple('ScopeIds', 'user_id block_type def_id usage_id')  # pylint: disable=C0103
 
 

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -406,9 +406,7 @@ class Runtime(object):
         """
         raise NotImplementedError("Runtime needs to provide publish()")
 
-
     # Construction
-
     def __init__(self, id_reader, field_data, mixins=(), services=None, default_class=None, select=None):
         """
         Arguments:
@@ -888,7 +886,7 @@ class NullI18nService(object):
         """
         Locale-aware strftime, with format short-cuts.
         """
-        format = self.STRFTIME_FORMATS.get(format+"_FORMAT", format)
+        format = self.STRFTIME_FORMATS.get(format + "_FORMAT", format)
         if isinstance(format, unicode):
             format = format.encode("utf8")
         return dtime.strftime(format).decode("utf8")

--- a/xblock/test/tools.py
+++ b/xblock/test/tools.py
@@ -11,7 +11,7 @@ from nose.tools import (                        # pylint: disable=W0611,E0611
     assert_true, assert_false,
     assert_equals, assert_not_equals,
     assert_is, assert_is_not,
-    assert_is_instance,
+    assert_is_instance, assert_is_none,
     assert_in, assert_not_in,
     assert_raises, assert_raises_regexp,
 )


### PR DESCRIPTION
@cpennington, @nedbat: It's mostly cleaned up. I'm going to be adding some test cases around ID generation and the store, but I'd appreciate a review on what's here if possible. Will squash before final commit.
### tldr;

Memory state storage replaced by Django model so you don't lose student state when the process reboots. Run `python manage.py syncdb`.
### Motivation

On edx-tim, we're using workbench to develop an app where part of the state is stored in django-backed apps, and part of the state is in the XBlock. Making edits to the code bounces the server causing XBlock state to be lost. This is painful.
### Approach

I created a `XBlockState` model so that we could take advantage of Django model admin tools for state introspection. `WorkbenchDjangoKeyValueStore` has replaced `WorkbenchMemoryKeyValueStore`. I also introduced `ScenarioIdManager` which will create scenario-local IDs. Scope IDs will now be of the format:

  `{scenario-description-slug}.{block_type}(.{slug}).d{def #}(.u{usage #})`

This feature abuses the fact that scenario loading for the most part simply overwrites the same keys with the same values (and will ignore the student state that's been created in the meanwhile). All the state that isn't student state is being recreated every time the server bounces. An exception to this are the children-scoped entries. Since that's an append-only operation, preserving the children scope entries between server startups would just cause it to grow longer and longer each time. So we kind of cheat and wipe all the children scope entries at startup.

While `ScenarioIdManager` makes the ID generation more stable between starts, your state can still get messed up if you have student state stored against a scenario that you are actively editing. To help with this problem, "reset state" buttons have been added to the block and index pages.

If you want to force workbench to reset all state when it restarts, you can set `settings.WORKBENCH["reset_state_on_restart"] = True` or set an environment variable `WORKBENCH_RESET_STATE_ON_RESTART=true` or start the server by saying `env WORKBENCH_RESET_STATE_ON_RESTART=true python manage.py runserver`
### Other Changes
- Instead of displaying global state inline with the block page, it's now a link that will take you to the admin page filtering on the scenario.
- Logging is also in its own scrolling div so that it doesn't make the page extremely long, and all Django database debug logging is filtered out of the output.
- Scenario XML is now displayed on the block page.
- Database settings can be overridden by setting the environment variable `WORKBENCH_DATABASES` to be a JSON representation of what you want `settings.DATABASES` to be set to.
### Limitations
- Performance was ignored a consideration. It could probably be made performant by being smarter about batch updates, but I didn't spend any time on it.
- Student state can get out of sync with definition/usage state if the scenarios are being moved around, requiring manual reset.

---

Much thanks to @nedbat for his guidance and debugging help.

![block](https://f.cloud.github.com/assets/41625/2322257/39e3111c-a3af-11e3-9706-2442773090fc.png)

![admin](https://f.cloud.github.com/assets/41625/2322259/3f3e4e9c-a3af-11e3-9cdd-abb376ac5259.png)
