### PR TITLE
Make DateTime field more permissive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ requests
 webob
 simplejson
 pytz
+python-dateutil
 
 # For Tests
 mock

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,7 @@ setup(
     install_requires=[
         'lxml',
         'webob',
+        'pytz',
+        'python-dateutil',
     ]
 )

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -6,10 +6,11 @@ for each scope.
 
 """
 
-import copy
 import datetime
+import copy
 from collections import namedtuple
 import pytz
+import dateutil.parser
 
 
 # __all__ controls what classes end up in the docs, and in what order.
@@ -611,7 +612,22 @@ class DateTime(Field):
         Parse the date from an ISO-formatted date string, or None.
         """
         if isinstance(value, basestring):
-            return datetime.datetime.strptime(value, self.DATETIME_FORMAT).replace(tzinfo=pytz.utc)
+
+            # Parser interprets empty string as now by default
+            if value == "":
+                return None
+
+            try:
+                parsed_date = dateutil.parser.parse(value)
+            except (TypeError, ValueError):
+                raise ValueError("Could not parse {} as a date".format(value))
+
+            if parsed_date.tzinfo is not None:
+                parsed_date.astimezone(pytz.utc)
+            else:
+                parsed_date = parsed_date.replace(tzinfo=pytz.utc)
+
+            return parsed_date
 
         if value is None:
             return None

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -182,6 +182,10 @@ class DateTest(FieldTest):
             dt.datetime(2014, 4, 1, 2, 3, 4).replace(tzinfo=pytz.utc),
             '2014-04-01T02:03:04.000000'
         )
+        self.assertJSONEquals(
+            dt.datetime(2014, 4, 1, 2, 3, 4).replace(tzinfo=pytz.utc),
+            '2014-04-01T02:03:04Z'
+        )
 
     def test_serialize(self):
         self.assertToJSONEquals(
@@ -196,6 +200,7 @@ class DateTest(FieldTest):
 
     def test_none(self):
         self.assertJSONEquals(None, None)
+        self.assertJSONEquals(None, '')
         self.assertEqual(DateTime().to_json(None), None)
 
     def test_error(self):
@@ -205,13 +210,8 @@ class DateTest(FieldTest):
         self.assertJSONTypeError(5.123)
 
     def test_date_format_error(self):
-        # Date format must exactly match what we're looking for:
-        # YYYY-MM-DDTHH:MM:SS.mmmmmmm
         with self.assertRaises(ValueError):
-            DateTime().from_json('2012-04-01')
-
-        with self.assertRaises(ValueError):
-            DateTime().from_json('')
+            DateTime().from_json('invalid')
 
     def test_serialize_error(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Further testing has revealed that Studio does directly manipulate the `start` and `due` field JSON representations.  This causes the edx-tim XBlock to raise a `ValueError` when it inherits these dates from a parent XBlock.

Given the tradeoffs, and the tight timeline for getting edx-tim released, I think using `dateutil.parser` is a good compromise.

@nedbat @ormsbee 
