### PR TITLE
Make doc references work better

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,7 +48,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'XBlock'
-copyright = u'2012\N{en dash}2013, edX.org'
+copyright = u'2012\N{en dash}2014, edX.org'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -96,6 +96,13 @@ pygments_style = 'sphinx'
 # When auto-doc'ing a class, write the class' docstring and the __init__ docstring
 # into the class docs.
 autoclass_content = "both"
+
+# Warn about unresolvable references, but not all of them.
+nitpicky = True
+nitpick_ignore = [
+    ('py:obj', 'str'),
+    ('py:obj', 'string'),
+]
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,4 +2,4 @@
 # can install them.
 
 sphinx
-sphinxcontrib-napoleon
+sphinxcontrib-napoleon==0.2.6

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -218,17 +218,18 @@ class XBlock(Plugin):
         """
         Construct a new XBlock.
 
-        This class should only be used by runtimes.
+        This class should only be instantiated by runtimes.
 
-        Parameters:
+        Arguments:
 
-            runtime (Runtime): Use it to access the environment.
+            runtime (:class:`.Runtime`): Use it to access the environment.
                 It is available in XBlock code as ``self.runtime``.
 
-            field_data (FieldData): Interface used by the XBlock
+            field_data (:class:`.FieldData`): Interface used by the XBlock
                 fields to access their data from wherever it is persisted.
 
-            scope_ids (ScopeIds): Identifiers needed to resolve scopes.
+            scope_ids (:class:`.ScopeIds`): Identifiers needed to resolve
+                scopes.
 
         """
         self.runtime = runtime
@@ -275,11 +276,11 @@ class XBlock(Plugin):
         return self._parent_block
 
     def render(self, view, context=None):
-        """Render `view` with this block's :class:`Runtime` and the supplied `context`"""
+        """Render `view` with this block's runtime and the supplied `context`"""
         return self.runtime.render(self, view, context)
 
     def handle(self, handler_name, request, suffix=''):
-        """Handle `request` with this block's :class:`Runtime`"""
+        """Handle `request` with this block's runtime."""
         return self.runtime.handle(self, handler_name, request, suffix)
 
     def save(self):
@@ -326,12 +327,18 @@ class XBlock(Plugin):
         """
         Use `node` to construct a new block.
 
-        Args:
-            node (etree.Element): The xml node to parse into an xblock
-            runtime (:class:`.Runtime`): The runtime to use while parsing
-            keys (:class:`.ScopeIds`): The keys identifying where this block will store its data
-            id_generator (:class:`.IdGenerator`): An object that will allow the runtime
-                to generate correct definition and usage ids for children of this block
+        Arguments:
+            node (etree.Element): The xml node to parse into an xblock.
+
+            runtime (:class:`.Runtime`): The runtime to use while parsing.
+
+            keys (:class:`.ScopeIds`): The keys identifying where this block
+                will store its data.
+
+            id_generator (:class:`.IdGenerator`): An object that will allow the
+                runtime to generate correct definition and usage ids for
+                children of this block.
+
         """
         block = runtime.construct_xblock_from_class(cls, keys)
 


### PR DESCRIPTION
Use the latest Napoleon plugin, which properly handles class references
in argument type parentheticals.  Change the Sphinx settings so that it
warns about missing references.  Update some docstrings to use the new
type links, and repair some missing references, but not all of them.
