### PR TITLE
Allow XBlocks to be used with django 1.6

### DIFF
--- a/django_requirements.txt
+++ b/django_requirements.txt
@@ -1,3 +1,3 @@
 # Install Django requirements, if we're using the optional Django-integrated
 # parts of XBlock
-Django >= 1.4, < 1.5
+Django >= 1.4, < 1.7


### PR DESCRIPTION
I didn't see any django 1.6 incompatibilities in the code, and neither did the tests.

@nedbat 
