### PR TITLE
allow .html files as a local resource

### DIFF
--- a/xblock/core.py
+++ b/xblock/core.py
@@ -163,9 +163,9 @@ class XBlock(Plugin):
         # Verify the URI is in whitelisted form before opening for serving.
         # URI must begin with public/, all file/folder names must use only
         # characters from [a-zA-Z0-9\-_], and the file type must be one of
-        # jpg, jpeg, png, gif, js, css, or json
+        # jpg, jpeg, png, gif, js, css, json or html
         assert re.match(
-            r'^public/([a-zA-Z0-9\-_]+/)*[a-zA-Z0-9\-_]+\.(jpg|jpeg|png|gif|js|css|json)$', uri
+            r'^public/([a-zA-Z0-9\-_]+/)*[a-zA-Z0-9\-_]+\.(jpg|jpeg|png|gif|js|css|json|html)$', uri
         )
         return pkg_resources.resource_stream(cls.__module__, uri)
 


### PR DESCRIPTION
The javascript courseware I'm trying to embed uses js libraries incompatible with edX, so I'd like to create an iframe in the xblock to hold my code.  I've written some simple js glue to allow the code inside the iframe to communicate with the xblock handlers.  In order to serve up the source of the iframe, it's necessary to allow .html files to be served as a local resource, along with css, js, json, etc.

iframe embedding seems like the most convenient and safest strategy to allow two different code bases to coexist both now and in the future.  This how, eg, Hangouts apps are embedded in to Hangout.
