### PR TITLE
Encode unicode as UTF-8 before passing it to cStringIO

### DIFF
--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -10,7 +10,7 @@ import threading
 
 from abc import ABCMeta, abstractmethod
 from lxml import etree
-from cStringIO import StringIO
+from StringIO import StringIO
 
 from collections import namedtuple
 from xblock.fields import Field, BlockScope, Scope, ScopeIds, UserScope

--- a/xblock/test/test_parsing.py
+++ b/xblock/test/test_parsing.py
@@ -118,6 +118,12 @@ class ParsingTest(XmlTest, unittest.TestCase):
         self.assertIsInstance(block, Specialized)
         self.assertEqual(block.num_children, 3)
 
+    @XBlock.register_temp_plugin(Leaf)
+    def test_parse_unicode(self):
+        block = self.parse_xml_to_block(u"<leaf data1='\u2603' />")
+        self.assertIsInstance(block, Leaf)
+        self.assertEqual(block.data1, u'\u2603')
+
 
 class ExportTest(XmlTest, unittest.TestCase):
     """Tests of the XML export facility."""


### PR DESCRIPTION
Discovered this while trying to import a scenario in workbench that contained non-ASCII unicode.

@sarina 
