### PR TITLE
Improve json_handler decorator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Brian Talbot <btalbot@edx.org>
 Chris Terman <cjt@mit.edu>
 Mike Dunn <mike@eikonomega.com>
 David Baumgold <david@davidbaumgold.com>
+Greg Price <gprice@edx.org>

--- a/xblock/exceptions.py
+++ b/xblock/exceptions.py
@@ -1,6 +1,11 @@
 """
 Module for all xblock exception classes
 """
+from webob import Response
+try:
+    import simplesjson as json  # pylint: disable=F0401
+except ImportError:
+    import json
 
 
 class XBlockNotFoundError(Exception):
@@ -92,3 +97,27 @@ class NoSuchUsage(Exception):
 class NoSuchDefinition(Exception):
     """Raised by :meth:`.IdReader.get_block_type` if the definition doesn't exist."""
     pass
+
+
+class JsonHandlerError(Exception):
+    """
+    Raised by a function decorated with XBlock.json_handler to indicate that an
+    error response should be returned.
+    """
+    def __init__(self, status_code, message):
+        self.status_code = status_code
+        self.message = message
+
+    def get_response(self, **kwargs):
+        """
+        Returns a Response object containing this object's status code and a
+        JSON object containing the key "error" with the value of this object's
+        error message in the body. Keyword args are passed through to
+        the Response.
+        """
+        return Response(
+            json.dumps({"error": self.message}),
+            status_code=self.status_code,
+            content_type="application/json",
+            **kwargs
+        )


### PR DESCRIPTION
It will now sanely respond with a 400 error if the input is invalid, and
the wrapped function can indicate by raising a certain exception that a
status code other than 200 or 500 should be returned.

@cpennington @nedbat 
