### PR TITLE
Relax open_local_resource rules.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pylint == 1.1.0
 rednose
 pep8
 diff-cover >= 0.2.1
+ddt==0.8.0
 
 # For docs
 -r doc/requirements.txt

--- a/xblock/exceptions.py
+++ b/xblock/exceptions.py
@@ -105,6 +105,7 @@ class JsonHandlerError(Exception):
     error response should be returned.
     """
     def __init__(self, status_code, message):
+        super(JsonHandlerError, self).__init__()
         self.status_code = status_code
         self.message = message
 
@@ -121,3 +122,8 @@ class JsonHandlerError(Exception):
             content_type="application/json",
             **kwargs
         )
+
+
+class DisallowedFileError(Exception):
+    """Raised by :meth:`open_local_resource` if the requested file is not allowed."""
+    pass

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -380,6 +380,11 @@ class Runtime(object):
              get_local_resource(uri) method should be able to open the resource
              identified by this uri.
 
+        Typically, this function uses `open_local_resource` defined on the
+        XBlock class, which by default will only allow resources from the
+        "public/" directory of the kit.  Resources must be placed in "public/"
+        to be successfully served with this URL.
+
         The return value is a complete absolute URL which will locate the
         resource on your runtime.
         """


### PR DESCRIPTION
An XBlock developer couldn't figure out why his static files weren't
serving.  At the very least, dots in the filename should be ok.
