### PR TITLE
Allow a json_handler to return a Response object

### DIFF
--- a/xblock/core.py
+++ b/xblock/core.py
@@ -119,10 +119,13 @@ class XBlock(Plugin):
             except ValueError:
                 return JsonHandlerError(400, "Invalid JSON").get_response()
             try:
-                response_json = json.dumps(func(self, request_json, suffix))
+                response = func(self, request_json, suffix)
             except JsonHandlerError as err:
                 return err.get_response()
-            return Response(response_json, content_type='application/json')
+            if isinstance(response, Response):
+                return response
+            else:
+                return Response(json.dumps(response), content_type='application/json')
         return wrapper
 
     @classmethod

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -13,6 +13,7 @@ import re
 import unittest
 
 import ddt
+from webob import Response
 
 from xblock.core import XBlock
 from xblock.exceptions import XBlockSaveError, KeyValueMultiSaveError, JsonHandlerError, DisallowedFileError
@@ -918,6 +919,19 @@ def test_json_handler_error():
     assert_equals(response.status_code, test_status_code)
     assert_equals(json.loads(response.body), {"error": test_message})
     assert_equals(response.content_type, "application/json")
+
+
+def test_json_handler_return_response():
+    test_request = Mock(method="POST", body="{}")
+
+    @XBlock.json_handler
+    def test_func(self, request, suffix):  # pylint: disable=unused-argument
+        return Response(body="not JSON", status=418, content_type="text/plain")
+
+    response = test_func(Mock(), test_request, "dummy_suffix")
+    assert_equals(response.body, "not JSON")
+    assert_equals(response.status_code, 418)
+    assert_equals(response.content_type, "text/plain")
 
 
 @ddt.ddt


### PR DESCRIPTION
It's useful to allow a `json_handler` view to return a full-fledged Response object if necessary, to account for edge-cases in APIs. This pull request allows you to return a Response object from a `json_handler` view,, and have it proxied along with no further processing.
