### PR TITLE
Correct declaration for scope_key.

### DIFF
--- a/xblock/reference/plugins.py
+++ b/xblock/reference/plugins.py
@@ -7,66 +7,16 @@ The README file in this directory contains much more information.
 Much of this still needs to be organized.
 """
 
-
-import json
-
 from djpyfs import djpyfs
 
 from xblock.fields import Field, NO_CACHE_VALUE
 from xblock.fields import UserScope, BlockScope
+from xblock.fields import scope_key
 
 #  Finished services
 #    None yet
 #
 #  edX-internal prototype services
-
-
-#  TODO:
-#  * Move somewhere useful.
-#  * Clean up how key is generated
-#  * Include field name, if not there yet?
-#  * Test. This appears to work, but next PR will use this, and more
-#    rigorous verification.
-def scope_key(instance, xblock):
-    """
-    Generate a unique key for a scope that can be used as a
-    filename, in a URL, or in a KVS.
-    """
-    scope_key_dict = {}
-    if instance.scope.user == UserScope.NONE or instance.scope.user == UserScope.ALL:
-        pass
-    elif instance.scope.user == UserScope.ONE:
-        scope_key_dict['user'] = unicode(xblock.scope_ids.user_id)
-    else:
-        raise NotImplementedError()
-
-    if instance.scope.block == BlockScope.TYPE:
-        # TODO: Is this correct? Was usage_id
-        scope_key_dict['block'] = unicode(xblock.scope_ids.block_type)
-    elif instance.scope.block == BlockScope.USAGE:
-        # TODO: Is this correct? was def_id. # Seems to be the same as usage?
-        scope_key_dict['block'] = unicode(xblock.scope_ids.usage_id)
-    elif instance.scope.block == BlockScope.DEFINITION:
-        scope_key_dict['block'] = unicode(xblock.scope_ids.def_id)
-    elif instance.scope.block == BlockScope.ALL:
-        pass
-    else:
-        raise NotImplementedError()
-
-    basekey = json.dumps(scope_key_dict, sort_keys=True, separators=(',', ':'))
-
-    def encode(char):
-        """
-        Replace all non-alphanumeric characters with _n_ where n
-        is their ASCII code.
-        """
-        if char.isalnum():
-            return char
-        else:
-            return "_{}_".format(ord(char))
-    encodedkey = "".join(encode(char) for char in basekey)
-
-    return encodedkey
 
 
 def public(type=None, **kwargs):  # pylint disable=unused-argument

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -21,6 +21,7 @@ from xblock.fields import (
 )
 
 from xblock.test.tools import assert_equals, assert_not_equals, assert_not_in
+from xblock.fields import scope_key, ScopeIds
 
 
 class FieldTest(unittest.TestCase):
@@ -390,6 +391,41 @@ def test_field_name_defaults():
         field_x = List()
 
     assert_equals("field_x", TestBlock.field_x.display_name)
+
+
+def test_scope_key():
+    # Tests field display name default values
+    class TestBlock(XBlock):
+        """
+        Block for testing
+        """
+        field_x = List(scope=Scope.settings, name='')
+        settings_lst = List(scope=Scope.settings, name='')
+        uss_lst = List(scope=Scope.user_state_summary, name='')
+        user_lst = List(scope=Scope.user_state, name='')
+        pref_lst = List(scope=Scope.preferences, name='')
+        user_info_lst = List(scope=Scope.user_info, name='')
+
+    sids = ScopeIds(user_id="_bob",
+                    block_type="b.12#ob",
+                    def_id="..",
+                    usage_id="..")
+
+    field_data = DictFieldData({})
+
+    from test_runtime import TestRuntime
+    runtime = TestRuntime(Mock(), field_data, [])
+    block = TestBlock(runtime, field_data, sids)
+
+    # Format: usage or block ID/field_name/user_id
+    for item, correct_key in [[TestBlock.field_x, "__..../field__x/NONE.NONE"],
+                              [TestBlock.user_info_lst, "NONE.NONE/user__info__lst/____bob"],
+                              [TestBlock.pref_lst, "b..12_35_ob/pref__lst/____bob"],
+                              [TestBlock.user_lst, "__..../user__lst/____bob"],
+                              [TestBlock.uss_lst, "__..../uss__lst/NONE.NONE"],
+                              [TestBlock.settings_lst, "__..../settings__lst/NONE.NONE"]]:
+        key = scope_key(item, block)
+        assert_equals(key, correct_key)
 
 
 def test_field_display_name():


### PR DESCRIPTION
@nedbat @cpennington Previously, this code was: 

1) Missing the field name. 
2) Gave relatively unclean keys. 

This PR fixes both issue. 

Rapid review would be appreciated, since we're about to start prototyping things on prod which rely on this. If we can get this out, it will save us a migration later. 
