### PR TITLE
Implemented error handling for XBlock instances

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ Bertrand Marron <bertrand.marron@ionis-group.com>
 Piotr Mitros <pmitros@edx.org>
 Daniel Li <swli@edx.org>
 John Eskew <jeskew@edx.org>
+Lucas Morales <lmorales@edx.org>

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -54,6 +54,8 @@ class Plugin(object):
 
     entry_point = None  # Should be overwritten by children classes
 
+    failed_loads, successful_loads = None, None
+
     # Temporary entry points, for register_temp_plugin.  A list of pairs,
     # (identifier, entry_point):
     #   [('test1', test1_entrypoint), ('test2', test2_entrypoint), ...]
@@ -115,26 +117,55 @@ class Plugin(object):
         return PLUGIN_CACHE[key]
 
     @classmethod
-    def load_classes(cls):
-        """Load all the classes for a plugin.
+    def _load_entry_points(cls, update=False):
+        """Load all the classes for a plugin, handle errors
 
         Produces a sequence containing the identifiers and their corresponding
-        classes for all of the available instances of this plugin.
+        classes for successfully loaded instances of this plugin, and a sequence
+        of dictionaries for all of the failed instances of this plugin.
 
         """
+        if not (update or cls.successful_loads is None):
+            return  # If we've loaded, and aren't forcing an update, use the old list.
+
+        cls.failed_loads, cls.successful_loads = [], []
         all_classes = itertools.chain(
             pkg_resources.iter_entry_points(cls.entry_point),
             (entry_point for identifier, entry_point in cls.extra_entry_points),
         )
         for class_ in all_classes:
             try:
-                yield (class_.name, cls._load_class_entry_point(class_))
-            except Exception:  # pylint: disable=broad-except
-                log.warning('Unable to load %s %r', cls.__name__, class_.name, exc_info=True)
+                cls.successful_loads.append((class_.name, cls._load_class_entry_point(class_)))
+            except Exception as exc:  # pylint: disable=broad-except
+                cls.failed_loads.append({
+                    "name": class_.name,
+                    "exception": exc
+                })
 
     @classmethod
-    def register_temp_plugin(cls, class_, identifier=None, dist='xblock'):
+    def load_classes(cls):
+        """
+        Returns sequence of tuples of successfully loaded instances (name, class)
+        """
+        cls._load_entry_points()
+        return cls.successful_loads
+
+    @classmethod
+    def failed_classes(cls):
+        """
+        Returns sequence of dictionaries for failed instances, with
+        attributes "name" and "exception" accordingly.
+        """
+        cls._load_entry_points()
+        return cls.failed_loads
+
+    @classmethod
+    def register_temp_plugin(cls, class_, identifier=None, dist='xblock', load_error=None):
         """Decorate a function to run with a temporary plugin available.
+
+        `identifier` is the class name for the plugin.
+        `dist` is irrelevant for XBlock and XBlock SDK, but may affect other things (e.g. edx-platform, possibly)
+        `load_error` is for testing: it forces the Mock entry point load to raise an Exception.
 
         Use it like this in tests::
 
@@ -150,7 +181,7 @@ class Plugin(object):
 
         entry_point = Mock(
             dist=Mock(key=dist),
-            load=Mock(return_value=class_),
+            load=Mock(return_value=load_error or class_),
         )
         entry_point.name = identifier
 
@@ -159,6 +190,7 @@ class Plugin(object):
             def _inner(*args, **kwargs):                # pylint: disable=C0111
                 old = list(cls.extra_entry_points)
                 cls.extra_entry_points.append((identifier, entry_point))
+                cls._load_entry_points(update=True)
                 try:
                     return func(*args, **kwargs)
                 finally:

--- a/xblock/test/test_plugin.py
+++ b/xblock/test/test_plugin.py
@@ -2,8 +2,6 @@
 Test xblock/core/plugin.py
 """
 
-from mock import patch, Mock
-
 from xblock.test.tools import (
     assert_is, assert_raises_regexp, assert_equals)
 
@@ -69,10 +67,10 @@ def test_nosuch_plugin():
         XBlock.load_class("nosuch_block")
 
 
-@patch.object(XBlock, '_load_class_entry_point', Mock(side_effect=Exception))
+@XBlock.register_temp_plugin(object, "bad_xblock", load_error=StandardError)
 def test_broken_plugin():
-    plugins = XBlock.load_classes()
-    assert_equals(list(plugins), [])
+    failures = XBlock.failed_classes()
+    assert any([failure["name"] == "bad_xblock" for failure in failures])
 
 
 def _num_plugins_cached():


### PR DESCRIPTION
Failed XBlock loads previously logged a warning that went nowhere. They are now stored in a list of failed XBlock instances (with their exception). @pmitros @nedbat 
