### PR TITLE
Add platform_settings Runtime directive

### DIFF
--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -412,7 +412,7 @@ class Runtime(object):
         raise NotImplementedError("Runtime needs to provide publish()")
 
     # Construction
-    def __init__(self, id_reader, field_data, mixins=(), services=None, default_class=None, select=None):
+    def __init__(self, id_reader, field_data, mixins=(), services=None, default_class=None, select=None, platform_settings={}):
         """
         Arguments:
             id_reader (IdReader): An object that allows the `Runtime` to
@@ -435,6 +435,8 @@ class Runtime(object):
                 when calling :meth:`.XBlock.load_class` to resolve a `block_type`.
                 This is the same `select` as used by :meth:`.Plugin.load_class`.
 
+            platform-settings (dictionary): a set of additional configuration
+                settings sent from our runtime into our xblock instances.
         """
         self.id_reader = id_reader
         self.field_data = field_data
@@ -449,6 +451,10 @@ class Runtime(object):
         self.user_id = None
         self.mixologist = Mixologist(mixins)
         self._view_name = None
+
+        # The XBlock configuration directives passed in from wherever this
+        # Runtime is embedded
+        self.platform_settings = platform_settings
 
     # Block operations
 


### PR DESCRIPTION
- Creates a way for platforms instantiating this Runtime to pass
  configuration directives to blocks via self.runtime.platform_settings
  member.
- platform_settings is a dictionary of values; every block gets
  instantiated with the same platform_settings on a particular platform,
  so settings intended for a particular XBlock should be namespaced to
  it in some way.

This is needed as part of the TrackChanges PR at https://github.com/edx/edx-ora2/pull/620. Combined with an appropriate change to edx-platform (PR # forthcoming as soon as I issue it), this enables platforms to have arbitrary configuration that they pass through to their XBlocks. Without that change, this does nothing.

I'm not sure who to tag for review.

@jbau FYI.
