### PR TITLE
Support for json-encoded strings for Dict field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ pylint.report
 diff_cover.html
 diff_quality_pep8.html
 diff_quality_pylint.html
+
+# IDE
+.idea

--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,5 @@ Piotr Mitros <pmitros@edx.org>
 Daniel Li <swli@edx.org>
 John Eskew <jeskew@edx.org>
 Lucas Morales <lmorales@edx.org>
+Eugeny Kolpakov <eugeny.kolpakov@gmail.com>
+David Bodor <david.gabor.bodor@gmail.com>

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -10,16 +10,20 @@ import warnings
 
 from xblock.exceptions import DisallowedFileError
 from xblock.fields import String, List, Scope
+import xblock.mixins
 from xblock.mixins import (
     ScopedStorageMixin,
     HierarchyMixin,
     RuntimeServicesMixin,
     HandlersMixin,
-    XmlSerializationMixin,
+    XmlSerializationMixin
 )
 from xblock.plugin import Plugin
 from xblock.validation import Validation
 
+# exposing XML_NAMESPACES as a member of core, in order to avoid importing mixins where
+# XML_NAMESPACES are needed (e.g. runtime.py).
+XML_NAMESPACES = xblock.mixins.XML_NAMESPACES
 
 # __all__ controls what classes end up in the docs.
 __all__ = ['XBlock']
@@ -179,7 +183,6 @@ class XBlock(XmlSerializationMixin, HierarchyMixin, ScopedStorageMixin, RuntimeS
         method, as there is currently only a no-op implementation.
         """
         return Validation(self.scope_ids.usage_id)
-
 
 # Maintain backwards compatibility
 import xblock.exceptions

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -24,7 +24,7 @@ from xblock.exceptions import (
     NoSuchDefinition,
     FieldDataDeprecationWarning,
 )
-from xblock.core import XBlock
+from xblock.core import XBlock, XML_NAMESPACES
 
 
 class KeyValueStore(object):
@@ -627,10 +627,10 @@ class Runtime(object):
         """
         Export the block to XML, writing the XML to `xmlfile`.
         """
-        root = etree.Element("unknown_root")
+        root = etree.Element("unknown_root", nsmap=XML_NAMESPACES)
         tree = etree.ElementTree(root)
         block.add_xml_to_node(root)
-        tree.write(xmlfile, xml_declaration=True, encoding="utf8")
+        tree.write(xmlfile, xml_declaration=True, pretty_print=True, encoding="utf8")
 
     def add_block_as_child_node(self, block, node):
         """

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -11,7 +11,12 @@ import unittest
 import datetime as dt
 import pytz
 import warnings
+import math
+import textwrap
+import itertools
 from contextlib import contextmanager
+
+import ddt
 
 from xblock.core import XBlock, Scope
 from xblock.field_data import DictFieldData
@@ -521,3 +526,164 @@ class SentinelTest(unittest.TestCase):
         self.assertEquals(a_dict[base], True)
         self.assertNotIn(Sentinel('foo'), a_dict)
         self.assertNotIn('base', a_dict)
+
+
+@ddt.ddt
+class FieldSerializationTest(unittest.TestCase):
+    """
+    Tests field.from_string and field.to_string methods.
+    """
+    def assert_to_string(self, _type, value, string):
+        """
+        Helper method: checks if _type's to_string given instance of _type returns expected string
+        """
+        result = _type(enforce_type=True).to_string(value)
+        self.assertEquals(result, string)
+
+    def assert_from_string(self, _type, string, value):
+        """
+        Helper method: checks if _type's from_string given string representation of type returns expected value
+        """
+        result = _type(enforce_type=True).from_string(string)
+        self.assertEquals(result, value)
+
+    @ddt.unpack
+    @ddt.data(
+        (Integer, 0, '0'),
+        (Integer, 5, '5'),
+        (Integer, -1023, '-1023'),
+        (Integer, 12345678, "12345678"),
+        (Float, 5.321, '5.321'),
+        (Float, -1023.35, '-1023.35'),
+        (Float, 1e+100, '1e+100'),
+        (Float, float('inf'), 'Infinity'),
+        (Float, float('-inf'), '-Infinity'),
+        (Boolean, True, "true"),
+        (Boolean, False, "false"),
+        (Integer, True, 'true'),
+        (String, "", ""),
+        (String, "foo", 'foo'),
+        (String, "bar", 'bar'),
+        (Dict, {}, '{}'),
+        (List, [], '[]'),
+        (Dict, {"foo": 1, "bar": 2}, textwrap.dedent("""\
+            {
+              "bar": 2,
+              "foo": 1
+            }""")),
+        (List, [1, 2, 3], textwrap.dedent("""\
+            [
+              1,
+              2,
+              3
+            ]""")),
+        (Dict, {"foo": [1, 2, 3], "bar": 2}, textwrap.dedent("""\
+            {
+              "bar": 2,
+              "foo": [
+                1,
+                2,
+                3
+              ]
+            }""")))
+    def test_both_directions(self, _type, value, string):
+        """Easy cases that work in both directions."""
+        self.assert_to_string(_type, value, string)
+        self.assert_from_string(_type, string, value)
+
+    @ddt.unpack
+    @ddt.data(
+        (Float, 0.0, r"0|0\.0*"),
+        (Float, 1.0, r"1|1\.0*"),
+        (Float, -10.0, r"-10|-10\.0*"))
+    def test_to_string_regexp_matches(self, _type, value, regexp):
+        result = _type(enforce_type=True).to_string(value)
+        self.assertRegexpMatches(result, regexp)
+
+    @ddt.unpack
+    @ddt.data(
+        (Integer, "0xff", 0xff),
+        (Integer, "0b01", 1),
+        (Integer, "0b10", 2),
+        (Float, '0', 0.0),
+        (Float, '0.0', 0.0),
+        (Float, '-10', -10.0),
+        (Float, '-10.0', -10.0),
+        (Boolean, 'TRUE', True),
+        (Boolean, 'FALSE', False),
+        (
+            Dict,
+            textwrap.dedent("""\
+                foo: 1
+                bar: 2.124
+                baz: True
+                kuu: some string
+            """),
+            {"foo": 1, "bar": 2.124, "baz": True, "kuu": "some string"}
+        ),
+        (
+            List,
+            textwrap.dedent("""\
+                - 1
+                - 2.345
+                - true
+                - false
+                - null
+                - some string
+            """),
+            [1, 2.345, True, False, None, "some string"]
+        ),
+        (
+            Dict,
+            textwrap.dedent("""\
+                foo: 1
+                bar: [1, 2, 3]
+            """),
+            {"foo": 1, "bar": [1, 2, 3]}
+        ),
+        (
+            Dict,
+            textwrap.dedent("""\
+                foo: 1
+                bar:
+                    - 1
+                    - 2
+                    - meow: true
+                      woof: false
+                      kaw: null
+            """),
+            {"foo": 1, "bar": [1, 2, {"meow": True, "woof": False, "kaw": None}]}
+        ),
+        (
+            List,
+            textwrap.dedent("""\
+                - 1
+                - 2.345
+                - {"foo": true, "bar": [1,2,3]}
+                - meow: false
+                  woof: true
+                  kaw: null
+            """),
+            [1, 2.345, {"foo": True, "bar": [1, 2, 3]}, {"meow": False, "woof": True, "kaw": None}]
+        )
+    )
+    def test_from_string(self, _type, string, value):
+        self.assert_from_string(_type, string, value)
+
+    def test_float_from_NaN_is_nan(self):  # pylint: disable=invalid-name
+        """Test parsing of NaN.
+
+        This special test case is necessary since
+        float('nan') compares inequal to everything.
+        """
+        result = Float(enforce_type=True).from_string('NaN')
+        self.assertTrue(math.isnan(result))
+
+    @ddt.unpack
+    @ddt.data(*itertools.product(
+        [Integer, Float],
+        ['{"foo":"bar"}', '[1, 2, 3]', 'baz', '1.abc', 'defg']))
+    def test_from_string_errors(self, _type, string):
+        """ Cases that raises various exceptions."""
+        with self.assertRaises(StandardError):
+            _type(enforce_type=True).from_string(string)


### PR DESCRIPTION
This patch allows setting a json-encoded `dict` to Dict fields, e.g. via data attributes in workbench scenarios.
- Motivation: Dict field only allows setting `dict` instances or None. This makes integration and manual testing with workbench problematic, as fields of this type can't be set using XML format.
- Affected components: all XBlocks using `Dict` fields, backward compatible with existing setups.
- Affected users: all
- Testing guidelines: run unittests
- Partner information: 3rd party-hosted open edX instance, for an edX solutions client (so will need to get some sort of solution merged in)
- Merge deadline: Oct 21 (soft requirement to minimize code drift, we maintain it on the client fork in the meantime)
