### PR TITLE
Implement callable field defaults.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ Bertrand Marron <bertrand.marron@ionis-group.com>
 Piotr Mitros <pmitros@edx.org>
 Daniel Li <swli@edx.org>
 John Eskew <jeskew@edx.org>
+Matjaz Gregoric <mtyaka@gmail.com>

--- a/xblock/field_data.py
+++ b/xblock/field_data.py
@@ -79,6 +79,18 @@ class FieldData(object):
         except KeyError:
             return False
 
+    @abstractmethod
+    def is_writable(self, block, name):
+        """
+        Return whether the field named `name` is writable on the XBlock `block`.
+
+        :param block: block to check
+        :type block: :class:`~xblock.core.XBlock`
+        :param name: field name
+        :type name: str
+        """
+        raise NotImplementedError
+
     def set_many(self, block, update_dict):
         """
         Update many fields on an XBlock simultaneously.
@@ -123,6 +135,9 @@ class DictFieldData(FieldData):
 
     def has(self, block, name):
         return name in self._data
+
+    def is_writable(self, block, name):
+        return True
 
     def set_many(self, block, update_dict):
         self._data.update(copy.deepcopy(update_dict))
@@ -173,6 +188,9 @@ class SplitFieldData(FieldData):
     def has(self, block, name):
         return self._field_data(block, name).has(block, name)
 
+    def is_writable(self, block, name):
+        return self._field_data(block, name).is_writable(block, name)
+
     def default(self, block, name):
         return self._field_data(block, name).default(block, name)
 
@@ -196,6 +214,9 @@ class ReadOnlyFieldData(FieldData):
 
     def has(self, block, name):
         return self._source.has(block, name)
+
+    def is_writable(self, block, name):
+        return False
 
     def default(self, block, name):
         return self._source.default(block, name)

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -203,6 +203,9 @@ class KvsFieldData(FieldData):
         except KeyError:
             return False
 
+    def is_writable(self, block, name):
+        return True
+
     def set_many(self, block, update_dict):
         """Update the underlying model with the correct values."""
         updated_dict = {}

--- a/xblock/test/test_field_data.py
+++ b/xblock/test/test_field_data.py
@@ -62,6 +62,11 @@ class TestSplitFieldData(object):
         self.content.has.assert_called_once_with(self.block, 'content')
         assert_false(self.settings.has.called)
 
+    def test_is_writable(self):
+        self.split.is_writable(self.block, 'content')
+        self.content.is_writable.assert_called_once_with(self.block, 'content')
+        assert_false(self.settings.is_writable.called)
+
     def test_set_many(self):
         self.split.set_many(self.block, {'content': 'new content', 'settings': 'new settings'})
         self.content.set_many.assert_called_once_with(self.block, {'content': 'new content'})
@@ -113,3 +118,6 @@ class TestReadOnlyFieldData(object):
     def test_has(self):
         assert_equals(self.source.has.return_value, self.read_only.has(self.block, 'content'))
         self.source.has.assert_called_once_with(self.block, 'content')
+
+    def test_is_writable(self):
+        assert_false(self.read_only.is_writable(self.block, 'content'))


### PR DESCRIPTION
This patch implements support for callable field defaults.

One of the use cases is to be able to set the field to a random
value at block creation time, for example:

```
my_field = String(scope=Scope.settings, default: lambda: uuid4().hex)
```

The standard way to do this without support for callable defaults
is to use a lazy property to populate the field when it is first accessed,
or to generate the default value inside a view. Callable field defaults
provide a more concise way to do it.

Static defaults are not persisted on save, but callable defaults need to
be persisted to be useful, especially when they generate a random value.
This patch introduces a new field parameter `persist_default` that let's
you control whether the default value should be persisted when `save()`
is called. If not given, `persist_default` is `True` for callable defaults
and `False` for static defaults to maintain backwards compatibility.

One difficulty with defaults that persist on save is that the default
value might get generated in a context where it cannot be persisted.
The LMS for example won't write to `content` or `settings` scopes.

This patch introduces `FieldData.is_writable(self, block, name)` method
to be able to only persist default values that can be persisted
in the current context.

Callable defaults were briefly discussed in
https://groups.google.com/forum/#!topic/edx-code/eRZtQ7t4JJY.

Callable defaults as a proof of concept were implemented in the
edx-solutions fork:
https://github.com/edx-solutions/XBlock/commit/f0112919e625ef037d1f

Several edx-solutions XBlocks have been using this feature, for example:
https://github.com/edx-solutions/xblock-discussion/blob/bcd0dcb1c00e07e7/discussion_forum/discussion_forum.py#L49-L51
- Partner information: 3rd party-hosted open edX instance, for an edX solutions client (so will need to get some sort of solution merged in)
- Merge deadline: 30th November (soft requirement to minimize code drift, we maintain it on the client fork in the meantime)

Two questions for the reviewers:
- Does it make sense to expose the `persist_default` setting?
  Would it be acceptable if `persist_default` always defaulted to
  `True` (event for static defaults)?
- Is it worth adding `FieldData.is_writtable` to avoid failing with
  an error when trying to write default values to a read-only backend?
  Would it actually be preferrable to fail in that case?
