### PR TITLE
Introduce validation method and class in XBlock API

### DIFF
--- a/xblock/core.py
+++ b/xblock/core.py
@@ -16,6 +16,7 @@ from webob import Response
 from xblock.exceptions import XBlockSaveError, KeyValueMultiSaveError, JsonHandlerError, DisallowedFileError
 from xblock.fields import ChildrenModelMetaclass, ModelMetaclass, String, List, Scope, Reference
 from xblock.plugin import Plugin
+from xblock.validation import Validation
 
 
 # __all__ controls what classes end up in the docs.
@@ -411,3 +412,10 @@ class XBlock(Plugin):
             return self.content
         else:
             return None
+
+    def validate(self):
+        """
+        Ask this xblock to validate itself. Subclasses are expected to override this
+        method, as there is currently only a no-op implementation.
+        """
+        return Validation(self.scope_ids.usage_id)

--- a/xblock/test/test_validation.py
+++ b/xblock/test/test_validation.py
@@ -1,0 +1,106 @@
+"""
+Test xblock/validation.py
+"""
+
+import unittest
+from xblock.test.tools import assert_raises
+
+from xblock.validation import ValidationMessage, Validation
+
+
+class ValidationMessageTest(unittest.TestCase):
+    """
+    Tests for `ValidationMessage`
+    """
+
+    def test_bad_parameters(self):
+        """
+        Test that `TypeError`s are thrown for bad input parameters.
+        """
+        with assert_raises(TypeError):
+            ValidationMessage("unknown type", u"Unknown type info")
+
+        with assert_raises(TypeError):
+            ValidationMessage(ValidationMessage.WARNING, "Non-unicode message")
+
+    def test_to_json(self):
+        """
+        Test the `to_json` method.
+        """
+        expected = {"type": ValidationMessage.ERROR, "text": u"Error message"}
+        self.assertEqual(expected, ValidationMessage(ValidationMessage.ERROR, u"Error message").to_json())
+
+        expected = {"type": ValidationMessage.WARNING, "text": u"Warning message"}
+        self.assertEqual(expected, ValidationMessage(ValidationMessage.WARNING, u"Warning message").to_json())
+
+
+class ValidationTest(unittest.TestCase):
+    """
+    Tests for `Validation` class.
+    """
+
+    def test_empty(self):
+        """
+        Test that `empty` return True iff there are no messages.
+        Also test the "bool" property of `Validation`.
+        """
+        validation = Validation("id")
+        self.assertTrue(validation.empty)
+        self.assertTrue(validation)
+
+        validation.add(ValidationMessage(ValidationMessage.ERROR, u"Error message"))
+        self.assertFalse(validation.empty)
+        self.assertFalse(validation)
+
+    def test_add_messages(self):
+        """
+        Test the behavior of adding the messages from another `Validation` object to this instance.
+        """
+        validation_1 = Validation("id")
+        validation_1.add(ValidationMessage(ValidationMessage.ERROR, u"Error message"))
+
+        validation_2 = Validation("id")
+        validation_2.add(ValidationMessage(ValidationMessage.WARNING, u"Warning message"))
+
+        validation_1.add_messages(validation_2)
+        self.assertEqual(2, len(validation_1.messages))
+
+        self.assertEqual(ValidationMessage.ERROR, validation_1.messages[0].type)
+        self.assertEqual(u"Error message", validation_1.messages[0].text)
+
+        self.assertEqual(ValidationMessage.WARNING, validation_1.messages[1].type)
+        self.assertEqual(u"Warning message", validation_1.messages[1].text)
+
+    def test_add_messages_error(self):
+        """
+        Test that calling `add_messages` with something that is not a `Validation` instances throw an error.
+        """
+        validation = Validation("id")
+
+        with assert_raises(TypeError):
+            validation.add_messages("foo")
+
+    def test_to_json(self):
+        """
+        Test the ability to serialize a `Validation` instance.
+        """
+        validation = Validation("id")
+        expected = {
+            "xblock_id": "id",
+            "messages": [],
+            "is_empty": True
+        }
+        self.assertEqual(expected, validation.to_json())
+
+        validation.add(ValidationMessage(ValidationMessage.ERROR, u"Error message"))
+        validation.add(ValidationMessage(ValidationMessage.WARNING, u"Warning message"))
+
+        expected = {
+            "xblock_id": "id",
+            "messages": [
+                {"type": ValidationMessage.ERROR, "text": u"Error message"},
+                {"type": ValidationMessage.WARNING, "text": u"Warning message"}
+            ],
+            "is_empty": False
+        }
+        self.assertEqual(expected, validation.to_json())

--- a/xblock/validation.py
+++ b/xblock/validation.py
@@ -1,0 +1,118 @@
+"""
+Validation information for an xblock instance.
+"""
+
+
+class ValidationMessage(object):
+    """
+    A message containing validation information about an xblock.
+    """
+
+    WARNING = "warning"
+    ERROR = "error"
+
+    TYPES = [WARNING, ERROR]
+
+    def __init__(self, message_type, message_text):
+        """
+        Create a new message.
+
+        Args:
+            message_type (str): The type associated with this message. Most be included in `TYPES`.
+            message_text (unicode): The textual message.
+        """
+        if message_type not in self.TYPES:
+            raise TypeError("Unknown message_type: " + message_type)
+        if not isinstance(message_text, unicode):
+            raise TypeError("Message text must be unicode")
+        self.type = message_type
+        self.text = message_text
+
+    def to_json(self):
+        """
+        Convert to a json-serializable representation.
+
+        Returns:
+            dict: A dict representation that is json-serializable.
+        """
+        return {
+            "type": self.type,
+            "text": self.text
+        }
+
+
+class Validation(object):
+    """
+    An object containing validation information for an xblock instance.
+
+    An instance of this class can be used as a boolean to determine if the xblock has validation issues,
+    where `True` signifies that the xblock passes validation.
+    """
+
+    def __init__(self, xblock_id):
+        """
+        Create a `Validation` instance.
+
+        Args:
+            xblock_id (object): An identification object that must support conversion to unicode.
+        """
+        self.messages = []
+        self.xblock_id = xblock_id
+
+    @property
+    def empty(self):
+        """
+        Is this object empty (contains no messages)?
+
+        Returns:
+            bool: True iff this instance has no validation issues and therefore has no messages.
+        """
+        return not self.messages
+
+    def __bool__(self):
+        """
+        Extended to return True if `empty` returns True
+
+         Returns:
+            bool: True iff this instance has no validation issues.
+        """
+        return self.empty
+
+    __nonzero__ = __bool__
+
+    def add(self, message):
+        """
+        Add a new validation message to this instance.
+
+        Args:
+            message (ValidationMessage): A validation message to add to this instance's list of messages.
+        """
+        if not isinstance(message, ValidationMessage):
+            raise TypeError("Argument must of type ValidationMessage")
+        self.messages.append(message)
+
+    def add_messages(self, validation):
+        """
+        Adds all the messages in the specified `Validation` object to this instance's
+        messages array.
+
+        Args:
+            validation (Validation): An object containing the messages to add to this instance's messages.
+        """
+        if not isinstance(validation, Validation):
+            raise TypeError("Argument must be of type Validation")
+
+        self.messages.extend(validation.messages)
+
+    def to_json(self):
+        """
+        Convert to a json-serializable representation.
+
+        Returns:
+            dict: A dict representation that is json-serializable.
+        """
+        return {
+            "xblock_id": unicode(self.xblock_id),
+            "messages": [message.to_json() for message in self.messages],
+            "is_empty": self.empty
+        }


### PR DESCRIPTION
@cpennington and @dmitchell please review

You can see the Studio extension of the Validation class in common/lib/xmodule/xmodule/validation.py in https://github.com/edx/edx-platform/pull/5710 (which is still WIP so is not yet commented or tested).
