### PR TITLE
Consistently use empty instead of is_empty

### DIFF
--- a/xblock/test/test_validation.py
+++ b/xblock/test/test_validation.py
@@ -88,7 +88,7 @@ class ValidationTest(unittest.TestCase):
         expected = {
             "xblock_id": "id",
             "messages": [],
-            "is_empty": True
+            "empty": True
         }
         self.assertEqual(expected, validation.to_json())
 
@@ -101,6 +101,6 @@ class ValidationTest(unittest.TestCase):
                 {"type": ValidationMessage.ERROR, "text": u"Error message"},
                 {"type": ValidationMessage.WARNING, "text": u"Warning message"}
             ],
-            "is_empty": False
+            "empty": False
         }
         self.assertEqual(expected, validation.to_json())

--- a/xblock/validation.py
+++ b/xblock/validation.py
@@ -114,5 +114,5 @@ class Validation(object):
         return {
             "xblock_id": unicode(self.xblock_id),
             "messages": [message.to_json() for message in self.messages],
-            "is_empty": self.empty
+            "empty": self.empty
         }


### PR DESCRIPTION
@cpennington FYI, I noticed that I forgot to change "is_empty" to "empty" in the JSON representation.
