### PR TITLE
We require lazy. Docs were broken without it.

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,6 @@
 # Packages we need in order to build the docs, separated out so that rtfd.org
 # can install them.
 
+lazy
 sphinx
 sphinxcontrib-napoleon==0.2.6


### PR DESCRIPTION
xblock.readthedocs.org had empty API pages.  It would be great to get doc-building integrated into the Travis tests.  Unfortunately, the "broken doc build" actually is a successful run of Sphinx.... :(
