### PR TITLE
Remove many of the metaclasses from XBlock.

### DIFF
--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -18,6 +18,8 @@ import warnings
 import json
 import yaml
 
+from xblock.internal import Nameable
+
 
 # __all__ controls what classes end up in the docs, and in what order.
 __all__ = [
@@ -247,7 +249,7 @@ EXPLICITLY_SET = Sentinel("fields.EXPLICITLY_SET")
 NO_GENERATED_DEFAULTS = ('parent', 'children')
 
 
-class Field(object):
+class Field(Nameable):
     """
     A field class that can be used as a class attribute to define what data the
     class will want to refer to.
@@ -293,7 +295,6 @@ class Field(object):
     def __init__(self, help=None, default=UNSET, scope=Scope.content,  # pylint:disable=redefined-builtin
                  display_name=None, values=None, enforce_type=False,
                  xml_node=False, **kwargs):
-        self._name = "unknown"
         self.help = help
         self._enable_enforce_type = enforce_type
         if default is not UNSET:
@@ -316,7 +317,7 @@ class Field(object):
     def name(self):
         """Returns the name of this field."""
         # This is set by ModelMetaclass
-        return self._name
+        return self.__name__ or 'unknown'
 
     @property
     def values(self):
@@ -501,7 +502,7 @@ class Field(object):
         self._set_cached_value(xblock, copy.deepcopy(self.default))
 
     def __repr__(self):
-        return "<{0.__class__.__name__} {0._name}>".format(self)
+        return "<{0.__class__.__name__} {0.name}>".format(self)
 
     def _warn_deprecated_outside_JSONField(self):  # pylint: disable=invalid-name
         """Certain methods will be moved to JSONField.

--- a/xblock/internal.py
+++ b/xblock/internal.py
@@ -1,0 +1,71 @@
+"""
+Internal machinery used to make building XBlock family base classes easier.
+"""
+import functools
+import inspect
+
+
+class LazyClassProperty(object):
+    """
+    A descriptor that acts as a class-level @lazy.
+
+    That is, it behaves as a lazily loading class property by
+    executing the decorated method once, and then storing the result
+    in the class __dict__.
+    """
+    def __init__(self, constructor):
+        self.__constructor = constructor
+        self.__cache = {}
+        functools.wraps(self.__constructor)(self)
+
+    def __get__(self, instance, owner):
+        if owner not in self.__cache:
+            # If __constructor iterates over members, then we don't want to call it
+            # again in an infinite loop. So, preseed the __cache with None.
+            self.__cache[owner] = None
+            self.__cache[owner] = self.__constructor(owner)
+        return self.__cache[owner]
+
+
+class_lazy = LazyClassProperty  # pylint: disable=invalid-name
+
+
+class NamedAttributesMetaclass(type):
+    """
+    A metaclass which adds the __name__ attribute to all Nameable attributes
+    which are attributes of the instantiated class, or of its baseclasses.
+    """
+    def __new__(mcs, name, bases, attrs):
+        # Iterate over the attrs before they're bound to the class
+        # so that we don't accidentally trigger any __get__ methods
+        for attr_name, attr in attrs.iteritems():
+            if Nameable.needs_name(attr):
+                attr.__name__ = attr_name
+
+        # Iterate over all of the base classes, so that we can add
+        # names to any mixins that don't include this metaclass, but that
+        # do include Nameable attributes
+        for base in bases:
+            for attr_name, attr in inspect.getmembers(base, Nameable.needs_name):
+                attr.__name__ = attr_name
+
+        return super(NamedAttributesMetaclass, mcs).__new__(mcs, name, bases, attrs)
+
+
+class Nameable(object):
+    """
+    A base class for class attributes which, when used in concert with
+    :class:`.NamedAttributesMetaclass`, will be assigned a `__name__`
+    attribute based on what class attribute they are bound to.
+    """
+    __slots__ = ('__name__')
+
+    __name__ = None
+
+    @staticmethod
+    def needs_name(obj):
+        """
+        Return True if `obj` is a :class:`.Nameable` object that
+        hasn't yet been assigned a name.
+        """
+        return isinstance(obj, Nameable) and obj.__name__ is None

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -8,6 +8,7 @@ import functools
 import itertools
 import logging
 import pkg_resources
+from xblock.internal import class_lazy
 
 log = logging.getLogger(__name__)
 
@@ -43,21 +44,6 @@ def default_select(identifier, all_entry_points):
         raise AmbiguousPluginError(all_entry_points)
 
 
-class PluginMetaclass(type):
-    """
-    Initialize class vars per subclass
-    """
-    def __new__(mcs, name, bases, attrs):
-        """
-        Init the class vars
-        """
-        # Temporary entry points, for register_temp_plugin.  A list of pairs,
-        # (identifier, entry_point):
-        #   [('test1', test1_entrypoint), ('test2', test2_entrypoint), ...]
-        attrs['extra_entry_points'] = []
-        return super(PluginMetaclass, mcs).__new__(mcs, name, bases, attrs)
-
-
 class Plugin(object):
     """Base class for a system that uses entry_points to load plugins.
 
@@ -66,9 +52,17 @@ class Plugin(object):
         `entry_point`: The name of the entry point to load plugins from.
 
     """
-    __metaclass__ = PluginMetaclass
-
     entry_point = None  # Should be overwritten by children classes
+
+    @class_lazy
+    def extra_entry_points(cls):  # pylint: disable=no-self-argument
+        """
+        Temporary entry points, for register_temp_plugin.  A list of pairs,
+        (identifier, entry_point):
+
+        [('test1', test1_entrypoint), ('test2', test2_entrypoint), ...]
+        """
+        return []
 
     @classmethod
     def _load_class_entry_point(cls, entry_point):

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -291,14 +291,30 @@ class IdReader(object):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_aside_type(self, aside_def_id):
-        """Retrieve the asiode_type of a particular definition
+    def get_aside_type_from_usage(self, aside_id):
+        """
+        Retrieve the XBlockAside `aside_type` associated with this aside
+        usage id.
 
         Args:
-            aside_def_id: The id of the definition to query
+            aside_id: The usage id of the XBlockAside.
 
         Returns:
-            The `block_type` of the aside
+            The `aside_type` of the aside.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_aside_type_from_definition(self, aside_id):
+        """
+        Retrieve the XBlockAside `aside_type` associated with this aside
+        definition id.
+
+        Args:
+            aside_id: The definition id of the XBlockAside.
+
+        Returns:
+            The `aside_type` of the aside.
         """
         raise NotImplementedError()
 
@@ -406,9 +422,13 @@ class MemoryIdManager(IdReader, IdGenerator):
             except AttributeError:
                 raise NoSuchDefinition(repr(def_id))
 
-    def get_aside_type(self, aside_def_id):
-        """Get an aside's type by its definition id."""
-        return aside_def_id.aside_type
+    def get_aside_type_from_definition(self, aside_id):
+        """Get an aside's type from its definition id."""
+        return aside_id.aside_type
+
+    def get_aside_type_from_usage(self, aside_id):
+        """Get an aside's type from its usage id."""
+        return aside_id.aside_type
 
 
 class Runtime(object):

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -384,7 +384,7 @@ class DictTest(FieldTest):
 def test_field_name_defaults():
     # Tests field display name default values
     attempts = Integer()
-    attempts._name = "max_problem_attempts"
+    attempts.__name__ = "max_problem_attempts"
     assert_equals('max_problem_attempts', attempts.display_name)
 
     class TestBlock(XBlock):

--- a/xblock/test/test_internal.py
+++ b/xblock/test/test_internal.py
@@ -1,0 +1,87 @@
+"""Tests of the xblock.internal module."""
+
+from unittest import TestCase
+
+from xblock.internal import class_lazy, NamedAttributesMetaclass, Nameable
+
+
+class TestLazyClassProperty(TestCase):
+    """
+    Tests of @class_lazy.
+    """
+    class Base(object):
+        """Test class that uses @class_lazy."""
+        @class_lazy
+        def isolated_dict(cls):  # pylint: disable=no-self-argument
+            "Return a different dict for each subclass."
+            return {}
+
+    class Derived(Base):
+        """Test class that inherits a @class_lazy definition."""
+        pass
+
+    def test_isolation(self):
+        self.assertEqual({}, self.Base.isolated_dict)
+        self.assertEqual({}, self.Derived.isolated_dict)
+        self.assertIsNot(self.Base.isolated_dict, self.Derived.isolated_dict)
+
+
+class TestDescriptor(Nameable):
+    """Descriptor that returns itself for introspection in tests."""
+    def __get__(self, instance, owner):
+        return self
+
+
+class TestGetSetDescriptor(Nameable):
+    """Descriptor that returns itself for introspection in tests."""
+    def __get__(self, instance, owner):
+        return self
+
+    def __set__(self, instance, value):
+        pass
+
+
+class NamingTester(object):
+    """Class with several descriptors that should get names."""
+    __metaclass__ = NamedAttributesMetaclass
+
+    test_descriptor = TestDescriptor()
+    test_getset_descriptor = TestGetSetDescriptor()
+    test_nonnameable = object()
+
+    def meth(self):
+        "An empty method."
+        pass
+
+    @property
+    def prop(self):
+        "An empty property."
+        pass
+
+
+class InheritedNamingTester(NamingTester):
+    """Class with several inherited descriptors that should get names."""
+    inherited = TestDescriptor()
+
+
+class TestNamedDescriptorsMetaclass(TestCase):
+    "Tests of the NamedDescriptorsMetaclass."
+
+    def test_named_descriptor(self):
+        self.assertEquals('test_descriptor', NamingTester.test_descriptor.__name__)
+
+    def test_named_getset_descriptor(self):
+        self.assertEquals('test_getset_descriptor', NamingTester.test_getset_descriptor.__name__)
+
+    def test_inherited_naming(self):
+        self.assertEquals('test_descriptor', InheritedNamingTester.test_descriptor.__name__)
+        self.assertEquals('inherited', InheritedNamingTester.inherited.__name__)
+
+    def test_unnamed_attribute(self):
+        self.assertFalse(hasattr(NamingTester.test_nonnameable, '__name__'))
+
+    def test_method(self):
+        self.assertEquals('meth', NamingTester.meth.__name__)
+
+    def test_prop(self):
+        self.assertFalse(hasattr(NamingTester.prop, '__name__'))


### PR DESCRIPTION
The majority of our metaclasses existed for one purpose: To add the
same variable to each created class that wouldn't be affected by
inheritance. For instance, a class might need to collect information
about which services it was requesting, and without a metaclass,
that _services_requested variable would be shared among all of the
subclasses of the RuntimeServicesMixin.

The second use of metaclasses was to add names to all XBlock Fields,
because those names are available at class construction, but not
to the Field object directly.

This commit removes the first class of metaclasses in favor of the
@class_lazy decorator, which calls a method one time per class, and
then returns the results of that method for every future access
of that class attribute.

The second class of metaclasses was abstracted into a single metaclass,
NamedAttributesMetaclass, which will add a **name** attribute to all
class attributes that are instances of Nameable. This should make
it easier to provide new and different types of declarative XBlock
interfaces in the future.
