### PR TITLE
Manually upgrade pip-tools to 6.5.0 to fix pip/pip-tools bug.

### DIFF
--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.0.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.0
     # via -r requirements/pip-tools.in
 tomli==2.0.0
     # via pep517


### PR DESCRIPTION
This failure started happening in the automated requirements upgrade:
https://github.com/openedx/XBlock/runs/5100983778?check_suite_focus=true

The bug was being caused by an interaction between pip and pip-tools, described here:
https://github.com/jazzband/pip-tools/issues/1558

The bug is fixed in pip-tools==6.5.0 - from this PR:
https://github.com/jazzband/pip-tools/pull/1567

Just bump the version manually to get the automated upgrades working again.