### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Change history for XBlock
 
 These are notable changes in XBlock.
 
+Unreleased
+----------
+
+* Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
+  deprecated.  See https://github.com/openedx/edx-sphinx-theme/issues/184 for
+  more details.
+
 1.6.1 - 2022-01-28
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@ import datetime
 import os
 import sys
 
-import edx_theme
 from unittest import mock
 
 
@@ -41,7 +40,6 @@ from xblock import __version__
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'edx_theme',
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.ifconfig',
@@ -57,9 +55,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-author = edx_theme.AUTHOR
+author = 'The Axim Collaborative'
 project = 'XBlock API Guide'
-copyright = f'{datetime.datetime.now().year}, edX Inc.'
+copyright = f'{datetime.datetime.now().year}, The Axim Collaborative'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -129,15 +127,45 @@ suppress_warnings = [
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'edx_theme'
+html_theme = 'sphinx_book_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+ "repository_url": "https://github.com/openedx/Xblock",
+ "repository_branch": "master",
+ "path_to_docs": "docs/",
+ "home_page_in_toc": True,
+ "use_repository_button": True,
+ "use_issues_button": True,
+ "use_edit_page_button": True,
+ # Please don't change unless you know what you're doing.
+ "extra_footer": """
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+            <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"/>
+        </a>
+        <br>
+        These works by
+            <a
+                xmlns:cc="https://creativecommons.org/ns#"
+                href="https://openedx.org"
+                property="cc:attributionName"
+                rel="cc:attributionURL"
+            >The Axim Collaborative</a>
+        are licensed under a
+            <a
+                rel="license"
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+            >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+    """
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [edx_theme.get_html_theme_path()]
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -148,12 +176,12 @@ html_theme_path = [edx_theme.get_html_theme_path()]
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = os.path.join(html_theme_path[0], 'edx_theme', 'static', 'css', 'favicon.ico')
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -5,6 +5,6 @@
 
 -r django.txt                       # Package dependencies, including optional Django support
 
-edx-sphinx-theme
+sphinx-book-theme
 mock
 sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 appdirs==1.4.4
@@ -11,7 +13,11 @@ appdirs==1.4.4
     #   -r requirements/django.txt
     #   fs
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.12.2
+    # via pydata-sphinx-theme
 boto3==1.26.113
     # via
     #   -r requirements/django.txt
@@ -31,9 +37,9 @@ django==2.2.28
     #   -r requirements/django.txt
     #   openedx-django-pyfs
 docutils==0.19
-    # via sphinx
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 fs==2.4.16
     # via
     #   -r requirements/django.txt
@@ -69,9 +75,16 @@ mock==5.0.1
 openedx-django-pyfs==3.2.1
     # via -r requirements/django.txt
 packaging==23.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.0
-    # via sphinx
+    # via
+    #   accessible-pygments
+    #   pydata-sphinx-theme
+    #   sphinx
 python-dateutil==2.8.2
     # via
     #   -r requirements/django.txt
@@ -94,17 +107,21 @@ simplejson==3.19.1
 six==1.16.0
     # via
     #   -r requirements/django.txt
-    #   edx-sphinx-theme
     #   fs
     #   fs-s3fs
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.4.1
+    # via beautifulsoup4
 sphinx==5.3.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -121,6 +138,8 @@ sqlparse==0.4.3
     # via
     #   -r requirements/django.txt
     #   django
+typing-extensions==4.5.0
+    # via pydata-sphinx-theme
 urllib3==1.26.15
     # via
     #   -r requirements/django.txt


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme. This removes references to the deprecated theme and replaces them with the new standard theme for the platform.

**Testing instructions:**
- Run `make docs` and see that the docs are generated properly and use the sphinx-book-theme

See https://github.com/openedx/edx-sphinx-theme/issues/184