### PR TITLE
Update setup.py, adds required packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,12 @@ setup(
     install_requires=[
         'fs',
         'lxml',
+        'mako',
         'markupsafe',
         'python-dateutil',
         'pytz',
         'pyyaml',
+        'simplejson',
         'webob',
         'web-fragments',
     ],

--- a/xblock/__init__.py
+++ b/xblock/__init__.py
@@ -27,4 +27,4 @@ class XBlockMixin(xblock.core.XBlockMixin):
 # without causing a circular import
 xblock.fields.XBlockMixin = XBlockMixin
 
-__version__ = '1.8.0'
+__version__ = '1.8.1'


### PR DESCRIPTION
Adding required package dependencies in the setup.py file after syncing it up with [base.in](https://github.com/openedx/XBlock/blob/master/requirements/base.in)

root cause found after the following test case failure:
https://github.com/openedx/DoneXBlock/actions/runs/6433150390/job/17469600711?pr=178#step:6:41

Ideally, we should add all the base.in packages in the `install_requires` of `setup.py` by code like [this](https://github.com/openedx-unsupported/xblock-utils/blob/master/setup.py#L139), can do it next PR.