### PR TITLE
fix: add missing ``xblock`` parameter in `get_javascript_i18n_catalog_url` | FC-0012

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ These are notable changes in XBlock.
 Unreleased
 ----------
 
+1.9.1 - 2023-12-22
+------------------
+
+* Fix: add ``get_javascript_i18n_catalog_url`` missing ``xblock`` parameter to match the Open edX LMS
+  XBlockI18nService.
+
 1.9.0 - 2023-11-20
 ------------------
 

--- a/xblock/__init__.py
+++ b/xblock/__init__.py
@@ -27,4 +27,4 @@ class XBlockMixin(xblock.core.XBlockMixin):
 # without causing a circular import
 xblock.fields.XBlockMixin = XBlockMixin
 
-__version__ = '1.9.0'
+__version__ = '1.9.1'

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -1357,9 +1357,12 @@ class NullI18nService:
         timestring = dtime.strftime(format)
         return timestring
 
-    def get_javascript_i18n_catalog_url(self):
+    def get_javascript_i18n_catalog_url(self, block):  # pylint: disable=unused-argument
         """
         Return the URL to the JavaScript i18n catalog file.
+
+        Args:
+            block (XBlock): The block that is requesting the URL.
 
         This method returns None in NullI18nService. When implemented in
         a runtime, it should return the URL to the JavaScript i18n catalog so

--- a/xblock/test/test_runtime.py
+++ b/xblock/test/test_runtime.py
@@ -524,7 +524,7 @@ class XBlockWithServices(XBlock):
         assert_equals_unicode("10:30:17 PM", i18n.strftime(when, "TIME"))
 
         # Runtimes are expected to implement this method though.
-        assert i18n.get_javascript_i18n_catalog_url() is None, 'NullI18nService does not implement this method.'
+        assert i18n.get_javascript_i18n_catalog_url(object()) is None, 'NullI18nService does not implement this method.'
 
         # secret_service is available.
         assert self.runtime.service(self, "secret_service") == 17


### PR DESCRIPTION
To match the Open edX LMS XBlockI18nService in test environments. Otherwise, tests in individual XBlock repositories will fail due to an incorrect definition in:

 - https://github.com/openedx/XBlock/pull/691

This does _not_ affect production code but it's blocking other pull requests from getting merged:

 - https://github.com/openedx/xblock-drag-and-drop-v2/pull/365

Already tested and works with:

  - https://github.com/openedx/xblock-drag-and-drop-v2/actions/runs/7303777534/job/19904885323

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
