### PR TITLE
build: do not run the upgrade action on forks

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,7 +2,6 @@ name: Upgrade Python Requirements
 
 on:
   schedule:
-    # will start the job at 01:30 UTC every Friday
     - cron: "0 0 * * 0"
   workflow_dispatch:
     inputs:
@@ -14,6 +13,8 @@ on:
 jobs:
   call-upgrade-python-requirements-workflow:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
+    # Do not run on forks
+    if: github.repository_owner == 'openedx'
     with:
       branch: ${{ github.event.inputs.branch || 'master' }}
       # optional parameters below; fill in if you'd like github or email notifications


### PR DESCRIPTION
In a typical use case, modifying the `master` branch on a fork is not desired.