### PR TITLE
Drop py3.8 support | Replace pkg_resources lib with importlib.resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
         toxenv: [quality, django42]
 
     steps:
@@ -34,7 +34,7 @@ jobs:
       run: tox -e ${{ matrix.toxenv }}
 
     - name: Run Coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv == 'django42'
+      if: matrix.python-version == '3.11' && matrix.toxenv == 'django42'
       uses: codecov/codecov-action@v4
       with:
         flags: unittests

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install pip
         run: pip install wheel setuptools

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,7 @@ formats:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.11"
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Change history for XBlock
 Unreleased
 ----------
 
+5.0.0 - 2024-05-30
+------------------
+
+* dropped python 3.8 support
+* transitioned from deprecated pkg_resources lib to importlib.resources
+
+
 4.1.0 - 2024-05-16
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ One Time Setup
    cd XBlock
 
    # Set up a virtualenv using virtualenvwrapper with the same name as the repo and activate it
-   mkvirtualenv -p python3.8 XBlock
+   mkvirtualenv -p python3.11 XBlock
 
 Every time you develop something in this repo
 ---------------------------------------------

--- a/docs/xblock-tutorial/getting_started/prereqs.rst
+++ b/docs/xblock-tutorial/getting_started/prereqs.rst
@@ -16,7 +16,7 @@ Python 3.11
 ***********
 
 To run the a virtual environment and the XBlock SDK, and to build an XBlock,
-you must have Python 3.1 installed on your computer.
+you must have Python 3.11 installed on your computer.
 
 `Download Python`_ for your operating system and follow the installation
 instructions.

--- a/docs/xblock-tutorial/getting_started/prereqs.rst
+++ b/docs/xblock-tutorial/getting_started/prereqs.rst
@@ -11,12 +11,12 @@ To build an XBlock, you must have the following tools on your computer.
  :depth: 1
 
 
-**********
-Python 3.8
-**********
+***********
+Python 3.11
+***********
 
 To run the a virtual environment and the XBlock SDK, and to build an XBlock,
-you must have Python 3.8 installed on your computer.
+you must have Python 3.1 installed on your computer.
 
 `Download Python`_ for your operating system and follow the installation
 instructions.
@@ -48,7 +48,7 @@ applications you might need.
 The instructions and examples in this tutorial use `VirtualEnv`_ and
 `VirtualEnvWrapper`_ to build XBlocks. You can also use `PyEnv`_.
 
-After you have installed Python 3.8, follow the `VirtualEnv Installation`_
+After you have installed Python 3.11, follow the `VirtualEnv Installation`_
 instructions.
 
 For information on creating the virtual environment for your XBlock, see

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,311,312}-django{42}, quality, docs
+envlist = py{311,312}-django{42}, quality, docs
 
 [pytest]
 DJANGO_SETTINGS_MODULE = xblock.test.settings
@@ -22,7 +22,7 @@ allowlist_externals =
 
 [testenv:docs]
 basepython =
-    python3.8
+    python3.11
 changedir =
     {toxinidir}/docs
 deps =

--- a/xblock/__init__.py
+++ b/xblock/__init__.py
@@ -2,4 +2,4 @@
 XBlock Courseware Components
 """
 
-__version__ = '4.1.1'
+__version__ = '5.0.0'

--- a/xblock/__init__.py
+++ b/xblock/__init__.py
@@ -2,4 +2,4 @@
 XBlock Courseware Components
 """
 
-__version__ = '4.1.0'
+__version__ = '4.1.1'

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -6,7 +6,6 @@ import functools
 import inspect
 import json
 import logging
-import os
 import warnings
 from collections import OrderedDict, defaultdict
 
@@ -161,8 +160,12 @@ class Blocklike(metaclass=_AutoNamedFieldsMetaclass):
 
     @classmethod
     def _open_resource(cls, uri):
-        return importlib.resources.files(inspect.getmodule(cls).__package__).joinpath(
-            os.path.join(cls.resources_dir, uri)
+        return importlib.resources.files(
+            inspect.getmodule(cls).__package__
+        ).joinpath(
+            cls.resources_dir
+        ).joinpath(
+            uri
         ).open('rb')
 
     @classmethod

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -10,7 +10,7 @@ import os
 import warnings
 from collections import OrderedDict, defaultdict
 
-import pkg_resources
+import importlib.resources
 from lxml import etree
 from webob import Response
 
@@ -157,7 +157,13 @@ class Blocklike(metaclass=_AutoNamedFieldsMetaclass):
         if "/." in uri:
             raise DisallowedFileError("Only safe file names are allowed: %r" % uri)
 
-        return pkg_resources.resource_stream(cls.__module__, os.path.join(cls.resources_dir, uri))
+        return cls.open_resource(uri)
+
+    @classmethod
+    def open_resource(cls, uri):
+        return importlib.resources.files(inspect.getmodule(cls).__package__).joinpath(
+            os.path.join(cls.resources_dir, uri)
+        ).open('rb')
 
     @classmethod
     def json_handler(cls, func):

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -157,10 +157,10 @@ class Blocklike(metaclass=_AutoNamedFieldsMetaclass):
         if "/." in uri:
             raise DisallowedFileError("Only safe file names are allowed: %r" % uri)
 
-        return cls.open_resource(uri)
+        return cls._open_resource(uri)
 
     @classmethod
-    def open_resource(cls, uri):
+    def _open_resource(cls, uri):
         return importlib.resources.files(inspect.getmodule(cls).__package__).joinpath(
             os.path.join(cls.resources_dir, uri)
         ).open('rb')

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -4,9 +4,9 @@ Generic plugin support so we can find XBlocks.
 This code is in the Runtime layer.
 """
 import functools
+import importlib.metadata
 import itertools
 import logging
-import pkg_resources
 
 from xblock.internal import class_lazy
 
@@ -100,7 +100,11 @@ class Plugin:
             if select is None:
                 select = default_select
 
-            all_entry_points = list(pkg_resources.iter_entry_points(cls.entry_point, name=identifier))
+            all_entry_points = [
+                entry_point
+                for entry_point in importlib.metadata.entry_points(group=cls.entry_point)
+                if entry_point.name == identifier
+            ]
             for extra_identifier, extra_entry_point in iter(cls.extra_entry_points):
                 if identifier == extra_identifier:
                     all_entry_points.append(extra_entry_point)
@@ -133,7 +137,7 @@ class Plugin:
         contexts. Hence, the flag.
         """
         all_classes = itertools.chain(
-            pkg_resources.iter_entry_points(cls.entry_point),
+            importlib.metadata.entry_points(group=cls.entry_point),
             (entry_point for identifier, entry_point in iter(cls.extra_entry_points)),
         )
         for class_ in all_classes:

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -100,7 +100,7 @@ class Plugin:
             if select is None:
                 select = default_select
 
-            all_entry_points = importlib.metadata.entry_points(group=cls.entry_point, name=identifier)
+            all_entry_points = list(importlib.metadata.entry_points(group=cls.entry_point, name=identifier))
             for extra_identifier, extra_entry_point in iter(cls.extra_entry_points):
                 if identifier == extra_identifier:
                     all_entry_points.append(extra_entry_point)

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -100,11 +100,7 @@ class Plugin:
             if select is None:
                 select = default_select
 
-            all_entry_points = [
-                entry_point
-                for entry_point in importlib.metadata.entry_points(group=cls.entry_point)
-                if entry_point.name == identifier
-            ]
+            all_entry_points = importlib.metadata.entry_points(group=cls.entry_point, name=identifier)
             for extra_identifier, extra_entry_point in iter(cls.extra_entry_points):
                 if identifier == extra_identifier:
                     all_entry_points.append(extra_entry_point)

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -961,10 +961,9 @@ class OpenLocalResourceTest(unittest.TestCase):
         """Just something to load resources from."""
         resources_dir = None
 
-    def stub_resource_stream(self, module, name):
-        """Act like pkg_resources.resource_stream, for testing."""
-        assert module == "xblock.test.test_core"
-        return "!" + name + "!"
+    def stub_open_resource(self, uri):
+        """Act like xblock.core.Blocklike.open_resource, for testing."""
+        return "!" + uri + "!"
 
     @ddt.data(
         "public/hey.js",
@@ -976,7 +975,7 @@ class OpenLocalResourceTest(unittest.TestCase):
     )
     def test_open_good_local_resource(self, uri):
         loadable = self.LoadableXBlock(None, scope_ids=Mock())
-        with patch('pkg_resources.resource_stream', self.stub_resource_stream):
+        with patch('xblock.core.Blocklike.open_resource', self.stub_open_resource):
             assert loadable.open_local_resource(uri) == "!" + uri + "!"
             assert loadable.open_local_resource(uri.encode('utf-8')) == "!" + uri + "!"
 
@@ -990,7 +989,7 @@ class OpenLocalResourceTest(unittest.TestCase):
     )
     def test_open_good_local_resource_binary(self, uri):
         loadable = self.LoadableXBlock(None, scope_ids=Mock())
-        with patch('pkg_resources.resource_stream', self.stub_resource_stream):
+        with patch('xblock.core.Blocklike.open_resource', self.stub_open_resource):
             assert loadable.open_local_resource(uri) == "!" + uri.decode('utf-8') + "!"
 
     @ddt.data(
@@ -1004,7 +1003,7 @@ class OpenLocalResourceTest(unittest.TestCase):
     )
     def test_open_bad_local_resource(self, uri):
         loadable = self.LoadableXBlock(None, scope_ids=Mock())
-        with patch('pkg_resources.resource_stream', self.stub_resource_stream):
+        with patch('xblock.core.Blocklike.open_resource', self.stub_open_resource):
             msg_pattern = ".*: %s" % re.escape(repr(uri))
             with pytest.raises(DisallowedFileError, match=msg_pattern):
                 loadable.open_local_resource(uri)
@@ -1020,7 +1019,7 @@ class OpenLocalResourceTest(unittest.TestCase):
     )
     def test_open_bad_local_resource_binary(self, uri):
         loadable = self.LoadableXBlock(None, scope_ids=Mock())
-        with patch('pkg_resources.resource_stream', self.stub_resource_stream):
+        with patch('xblock.core.Blocklike.open_resource', self.stub_open_resource):
             msg = ".*: %s" % re.escape(repr(uri.decode('utf-8')))
             with pytest.raises(DisallowedFileError, match=msg):
                 loadable.open_local_resource(uri)
@@ -1043,7 +1042,7 @@ class OpenLocalResourceTest(unittest.TestCase):
     def test_open_local_resource_with_no_resources_dir(self, uri):
         unloadable = self.UnloadableXBlock(None, scope_ids=Mock())
 
-        with patch('pkg_resources.resource_stream', self.stub_resource_stream):
+        with patch('xblock.core.Blocklike.open_resource', self.stub_open_resource):
             msg = "not configured to serve local resources"
             with pytest.raises(DisallowedFileError, match=msg):
                 unloadable.open_local_resource(uri)

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -962,7 +962,7 @@ class OpenLocalResourceTest(unittest.TestCase):
         resources_dir = None
 
     def stub_open_resource(self, uri):
-        """Act like xblock.core.Blocklike.open_resource, for testing."""
+        """Act like xblock.core.Blocklike._open_resource, for testing."""
         return "!" + uri + "!"
 
     @ddt.data(
@@ -975,7 +975,7 @@ class OpenLocalResourceTest(unittest.TestCase):
     )
     def test_open_good_local_resource(self, uri):
         loadable = self.LoadableXBlock(None, scope_ids=Mock())
-        with patch('xblock.core.Blocklike.open_resource', self.stub_open_resource):
+        with patch('xblock.core.Blocklike._open_resource', self.stub_open_resource):
             assert loadable.open_local_resource(uri) == "!" + uri + "!"
             assert loadable.open_local_resource(uri.encode('utf-8')) == "!" + uri + "!"
 
@@ -989,7 +989,7 @@ class OpenLocalResourceTest(unittest.TestCase):
     )
     def test_open_good_local_resource_binary(self, uri):
         loadable = self.LoadableXBlock(None, scope_ids=Mock())
-        with patch('xblock.core.Blocklike.open_resource', self.stub_open_resource):
+        with patch('xblock.core.Blocklike._open_resource', self.stub_open_resource):
             assert loadable.open_local_resource(uri) == "!" + uri.decode('utf-8') + "!"
 
     @ddt.data(
@@ -1003,7 +1003,7 @@ class OpenLocalResourceTest(unittest.TestCase):
     )
     def test_open_bad_local_resource(self, uri):
         loadable = self.LoadableXBlock(None, scope_ids=Mock())
-        with patch('xblock.core.Blocklike.open_resource', self.stub_open_resource):
+        with patch('xblock.core.Blocklike._open_resource', self.stub_open_resource):
             msg_pattern = ".*: %s" % re.escape(repr(uri))
             with pytest.raises(DisallowedFileError, match=msg_pattern):
                 loadable.open_local_resource(uri)
@@ -1019,7 +1019,7 @@ class OpenLocalResourceTest(unittest.TestCase):
     )
     def test_open_bad_local_resource_binary(self, uri):
         loadable = self.LoadableXBlock(None, scope_ids=Mock())
-        with patch('xblock.core.Blocklike.open_resource', self.stub_open_resource):
+        with patch('xblock.core.Blocklike._open_resource', self.stub_open_resource):
             msg = ".*: %s" % re.escape(repr(uri.decode('utf-8')))
             with pytest.raises(DisallowedFileError, match=msg):
                 loadable.open_local_resource(uri)
@@ -1042,7 +1042,7 @@ class OpenLocalResourceTest(unittest.TestCase):
     def test_open_local_resource_with_no_resources_dir(self, uri):
         unloadable = self.UnloadableXBlock(None, scope_ids=Mock())
 
-        with patch('xblock.core.Blocklike.open_resource', self.stub_open_resource):
+        with patch('xblock.core.Blocklike._open_resource', self.stub_open_resource):
             msg = "not configured to serve local resources"
             with pytest.raises(DisallowedFileError, match=msg):
                 unloadable.open_local_resource(uri)

--- a/xblock/test/utils/test_resources.py
+++ b/xblock/test/utils/test_resources.py
@@ -5,9 +5,9 @@ Tests for resources.py
 
 import gettext
 import unittest
-from unittest.mock import patch, DEFAULT
+from unittest.mock import DEFAULT, patch
 
-from pkg_resources import resource_filename
+import importlib.resources
 
 from xblock.utils.resources import ResourceLoader
 
@@ -136,7 +136,7 @@ class MockI18nService:
     def __init__(self):
 
         locale_dir = 'data/translations'
-        locale_path = resource_filename(__name__, locale_dir)
+        locale_path = str(importlib.resources.files(__package__) / locale_dir)
         domain = 'text'
         self.mock_translator = gettext.translation(
             domain,

--- a/xblock/utils/resources.py
+++ b/xblock/utils/resources.py
@@ -22,7 +22,8 @@ class ResourceLoader:
         Gets the content of a resource
         """
         package_name = importlib.import_module(self.module_name).__package__
-        return importlib.resources.files(package_name).joinpath(resource_path.lstrip('/')).read_text()
+        # Strip leading slash to avoid importlib exception with absolute paths
+        return importlib.resources.files(package_name).joinpath(resource_path.lstrip('/')).read_text(encoding="utf-8")
 
     def render_django_template(self, template_path, context=None, i18n_service=None):
         """
@@ -56,7 +57,9 @@ class ResourceLoader:
         )
         context = context or {}
         template_str = self.load_unicode(template_path)
-        directory = os.path.dirname(os.path.realpath(sys.modules[self.module_name].__file__))
+
+        package_name = importlib.import_module(self.module_name).__package__
+        directory = str(importlib.resources.files(package_name))
         lookup = MakoTemplateLookup(directories=[directory])
         template = MakoTemplate(template_str, lookup=lookup)
         return template.render(**context)

--- a/xblock/utils/resources.py
+++ b/xblock/utils/resources.py
@@ -22,7 +22,7 @@ class ResourceLoader:
         Gets the content of a resource
         """
         package_name = importlib.import_module(self.module_name).__package__
-        return importlib.resources.files(package_name).joinpath(resource_path).read_text()
+        return importlib.resources.files(package_name).joinpath(resource_path.lstrip('/')).read_text()
 
     def render_django_template(self, template_path, context=None, i18n_service=None):
         """
@@ -56,8 +56,7 @@ class ResourceLoader:
         )
         context = context or {}
         template_str = self.load_unicode(template_path)
-        directory = str(importlib.resources.as_file(
-            importlib.resources.files(sys.modules[self.module_name].__package__)))
+        directory = os.path.dirname(os.path.realpath(sys.modules[self.module_name].__file__))
         lookup = MakoTemplateLookup(directories=[directory])
         template = MakoTemplate(template_str, lookup=lookup)
         return template.render(**context)

--- a/xblock/utils/resources.py
+++ b/xblock/utils/resources.py
@@ -22,7 +22,11 @@ class ResourceLoader:
         Gets the content of a resource
         """
         package_name = importlib.import_module(self.module_name).__package__
-        # Strip leading slash to avoid importlib exception with absolute paths
+        # TODO: Add encoding on other places as well
+        # resource_path should be a relative path, but historically some callers passed it in
+        # with a leading slash, which pkg_resources tolerated and ignored. importlib is less
+        # forgiving, so in order to maintain backwards compatibility, we must strip off the
+        # leading slash is there is one to ensure we actually have a relative path.
         return importlib.resources.files(package_name).joinpath(resource_path.lstrip('/')).read_text(encoding="utf-8")
 
     def render_django_template(self, template_path, context=None, i18n_service=None):


### PR DESCRIPTION
- Drop Py3.8 support 
- Replace pkg_resources lib with importlib.resources

Ticket: https://github.com/openedx/XBlock/issues/676

**Followed migration guide:** 
https://importlib-resources.readthedocs.io/en/latest/migration.html

**Testing:**
I have tested the changes with following steps:
1. Use [PR](https://github.com/openedx/xblock-sdk/pull/350) of `xblock-sdk`
2. Install `xblock` into `xblock-sdk`

3. Install `feedback-xblock` from [PR](https://github.com/openedx/FeedbackXBlock/pull/58) into `xblock-sdk`
4. Test feedback xblock functionality