### PR TITLE
Unpin the Django dependency

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -18,7 +18,7 @@ filelock==3.13.1
     # via
     #   tox
     #   virtualenv
-packaging==23.2
+packaging==24.0
     # via
     #   pyproject-api
     #   tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,11 +21,11 @@ attrs==23.2.0
     # via
     #   -r requirements/test.txt
     #   hypothesis
-boto3==1.34.59
+boto3==1.34.62
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.34.59
+botocore==1.34.62
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -56,7 +56,7 @@ click-log==0.4.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-code-annotations==1.6.0
+code-annotations==1.7.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -114,10 +114,11 @@ fs-s3fs==1.1.1
     # via
     #   -r requirements/test.txt
     #   openedx-django-pyfs
-hypothesis==6.99.0
+hypothesis==6.99.6
     # via -r requirements/test.txt
-importlib-metadata==7.0.2
+importlib-metadata==6.11.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/pip-tools.txt
     #   build
 inflect==7.0.0
@@ -168,7 +169,7 @@ mock==5.1.0
     # via -r requirements/test.txt
 openedx-django-pyfs==3.5.0
     # via -r requirements/test.txt
-packaging==23.2
+packaging==24.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -201,7 +202,7 @@ pluggy==1.4.0
     #   tox
 pycodestyle==2.11.1
     # via -r requirements/test.txt
-pydantic==2.6.3
+pydantic==2.6.4
     # via
     #   -r requirements/test.txt
     #   inflect
@@ -346,11 +347,11 @@ web-fragments==2.1.0
     # via -r requirements/test.txt
 webob==1.8.7
     # via -r requirements/test.txt
-wheel==0.42.0
+wheel==0.43.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-zipp==3.17.0
+zipp==3.18.0
     # via
     #   -r requirements/pip-tools.txt
     #   importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,6 +12,10 @@ appdirs==1.4.4
     # via
     #   -r requirements/test.txt
     #   fs
+asgiref==3.7.2
+    # via
+    #   -r requirements/test.txt
+    #   django
 astroid==3.1.0
     # via
     #   -r requirements/test.txt
@@ -21,6 +25,10 @@ attrs==23.2.0
     # via
     #   -r requirements/test.txt
     #   hypothesis
+backports-zoneinfo==0.2.1 ; python_version < "3.9"
+    # via
+    #   -r requirements/test.txt
+    #   django
 boto3==1.34.62
     # via
     #   -r requirements/test.txt
@@ -85,7 +93,7 @@ distlib==0.3.8
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   virtualenv
-django==2.2.28
+django==4.2.11
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -266,9 +274,7 @@ python-slugify==8.0.4
     #   -r requirements/test.txt
     #   code-annotations
 pytz==2024.1
-    # via
-    #   -r requirements/test.txt
-    #   django
+    # via -r requirements/test.txt
 pyyaml==6.0.1
     # via
     #   -r requirements/test.txt
@@ -328,6 +334,7 @@ typing-extensions==4.10.0
     # via
     #   -r requirements/test.txt
     #   annotated-types
+    #   asgiref
     #   astroid
     #   edx-opaque-keys
     #   inflect

--- a/requirements/django.in
+++ b/requirements/django.in
@@ -8,3 +8,7 @@
 Django
 openedx-django-pyfs>=1.0.5
 lazy
+
+# Needed until we drop testing on Python 3.8 so that
+# we don't try to install this on newer versions of python.
+backports.zoneinfo;python_version<"3.9"

--- a/requirements/django.in
+++ b/requirements/django.in
@@ -5,6 +5,6 @@
 
 -r base.txt                         # Core XBlock dependencies
 
-Django>=2.2,<3.0
+Django
 openedx-django-pyfs>=1.0.5
 lazy

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -8,9 +8,9 @@ appdirs==1.4.4
     # via
     #   -r requirements/base.txt
     #   fs
-boto3==1.34.59
+boto3==1.34.62
     # via fs-s3fs
-botocore==1.34.59
+botocore==1.34.62
     # via
     #   boto3
     #   s3transfer

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -8,13 +8,19 @@ appdirs==1.4.4
     # via
     #   -r requirements/base.txt
     #   fs
+asgiref==3.7.2
+    # via django
+backports-zoneinfo==0.2.1 ; python_version < "3.9"
+    # via
+    #   -r requirements/django.in
+    #   django
 boto3==1.34.62
     # via fs-s3fs
 botocore==1.34.62
     # via
     #   boto3
     #   s3transfer
-django==2.2.28
+django==4.2.11
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/django.in
@@ -59,9 +65,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/base.txt
     #   botocore
 pytz==2024.1
-    # via
-    #   -r requirements/base.txt
-    #   django
+    # via -r requirements/base.txt
 pyyaml==6.0.1
     # via -r requirements/base.txt
 s3transfer==0.10.0
@@ -83,6 +87,7 @@ stevedore==5.2.0
 typing-extensions==4.10.0
     # via
     #   -r requirements/base.txt
+    #   asgiref
     #   edx-opaque-keys
 urllib3==1.26.18
     # via botocore

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,11 +18,11 @@ babel==2.14.0
     #   sphinx
 beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
-boto3==1.34.59
+boto3==1.34.62
     # via
     #   -r requirements/django.txt
     #   fs-s3fs
-botocore==1.34.59
+botocore==1.34.62
     # via
     #   -r requirements/django.txt
     #   boto3
@@ -55,8 +55,10 @@ idna==3.6
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==7.0.2
-    # via sphinx
+importlib-metadata==6.11.0
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   sphinx
 jinja2==3.1.3
     # via sphinx
 jmespath==1.0.1
@@ -81,7 +83,7 @@ mock==5.1.0
     # via -r requirements/doc.in
 openedx-django-pyfs==3.5.0
     # via -r requirements/django.txt
-packaging==23.2
+packaging==24.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
@@ -170,7 +172,7 @@ web-fragments==2.1.0
     # via -r requirements/django.txt
 webob==1.8.7
     # via -r requirements/django.txt
-zipp==3.17.0
+zipp==3.18.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,10 +12,18 @@ appdirs==1.4.4
     # via
     #   -r requirements/django.txt
     #   fs
+asgiref==3.7.2
+    # via
+    #   -r requirements/django.txt
+    #   django
 babel==2.14.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
+backports-zoneinfo==0.2.1 ; python_version < "3.9"
+    # via
+    #   -r requirements/django.txt
+    #   django
 beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
 boto3==1.34.62
@@ -31,7 +39,7 @@ certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
-django==2.2.28
+django==4.2.11
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/django.txt
@@ -110,7 +118,6 @@ pytz==2024.1
     # via
     #   -r requirements/django.txt
     #   babel
-    #   django
 pyyaml==6.0.1
     # via -r requirements/django.txt
 requests==2.31.0
@@ -161,6 +168,7 @@ stevedore==5.2.0
 typing-extensions==4.10.0
     # via
     #   -r requirements/django.txt
+    #   asgiref
     #   edx-opaque-keys
     #   pydata-sphinx-theme
 urllib3==1.26.18

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,11 @@ build==1.1.1
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==7.0.2
-    # via build
-packaging==23.2
+importlib-metadata==6.11.0
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   build
+packaging==24.0
     # via build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in
@@ -23,9 +25,9 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.42.0
+wheel==0.43.0
     # via pip-tools
-zipp==3.17.0
+zipp==3.18.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.42.0
+wheel==0.43.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via -r requirements/pip.in
-setuptools==69.1.1
+setuptools==69.2.0
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,6 +10,10 @@ appdirs==1.4.4
     # via
     #   -r requirements/django.txt
     #   fs
+asgiref==3.7.2
+    # via
+    #   -r requirements/django.txt
+    #   django
 astroid==3.1.0
     # via
     #   -r requirements/test.in
@@ -17,6 +21,10 @@ astroid==3.1.0
     #   pylint-celery
 attrs==23.2.0
     # via hypothesis
+backports-zoneinfo==0.2.1 ; python_version < "3.9"
+    # via
+    #   -r requirements/django.txt
+    #   django
 boto3==1.34.62
     # via
     #   -r requirements/django.txt
@@ -185,9 +193,7 @@ python-dateutil==2.9.0.post0
 python-slugify==8.0.4
     # via code-annotations
 pytz==2024.1
-    # via
-    #   -r requirements/django.txt
-    #   django
+    # via -r requirements/django.txt
 pyyaml==6.0.1
     # via
     #   -r requirements/django.txt
@@ -233,6 +239,7 @@ typing-extensions==4.10.0
     # via
     #   -r requirements/django.txt
     #   annotated-types
+    #   asgiref
     #   astroid
     #   edx-opaque-keys
     #   inflect

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,11 +17,11 @@ astroid==3.1.0
     #   pylint-celery
 attrs==23.2.0
     # via hypothesis
-boto3==1.34.59
+boto3==1.34.62
     # via
     #   -r requirements/django.txt
     #   fs-s3fs
-botocore==1.34.59
+botocore==1.34.62
     # via
     #   -r requirements/django.txt
     #   boto3
@@ -37,7 +37,7 @@ click==8.1.7
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.6.0
+code-annotations==1.7.0
     # via edx-lint
 colorama==0.4.6
     # via tox
@@ -80,7 +80,7 @@ fs-s3fs==1.1.1
     # via
     #   -r requirements/django.txt
     #   openedx-django-pyfs
-hypothesis==6.99.0
+hypothesis==6.99.6
     # via -r requirements/test.in
 inflect==7.0.0
     # via jinja2-pluralize
@@ -119,7 +119,7 @@ mock==5.1.0
     # via -r requirements/test.in
 openedx-django-pyfs==3.5.0
     # via -r requirements/django.txt
-packaging==23.2
+packaging==24.0
     # via
     #   pyproject-api
     #   pytest
@@ -142,7 +142,7 @@ pluggy==1.4.0
     #   tox
 pycodestyle==2.11.1
     # via -r requirements/test.in
-pydantic==2.6.3
+pydantic==2.6.4
     # via inflect
 pydantic-core==2.16.3
     # via pydantic


### PR DESCRIPTION
We were explictly pinning django in django.in which is not necessary and makes it so your dev environment runs with and old version of django. The correct pin already exists in the common-constraints.txt file in edx-lint so we don't need to have an explicit pin here.  And for testing, the version is controlled via tox so it doesn't use this. It does effect dev and doc environments though so we should keep it up to date and make it harder to pin it in correctly.
