### PR TITLE
feat: re-add fragment as passthrough to webfragement.fragment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change history for XBlock
 Unreleased
 ----------
 
+4.0.0 - 2024-04-18
+------------------
+
+* xblock.fragment has returned as a pass-though component to web_fragments.fragment
+
 
 3.0.0 - 2024-03-18
 ------------------
@@ -15,7 +20,7 @@ will be unaffected by this change. Some improvements have also been made to the 
 
 Specific changes:
 
-* **Removed:** 
+* **Removed:**
 
   * ``xblock.XBlockMixin`` (still available as ``xblock.core.XBlockMixin``)
   * ``xblock.core.SharedBlockBase`` (replaced with ``xblock.core.Blocklike``)
@@ -53,7 +58,7 @@ Specific changes:
 
   * Various docstrings have been improved, some of which are published in the docs.
   * XBlockAside will now be represented in the API docs, right below XBlock on the "XBlock API" page.
-  * XBlockMixin has been removed from the docs. 
+  * XBlockMixin has been removed from the docs.
     It was only ever documented under the "Fields API" page (which didn't make any sense),
     and it was barely even documented there. We considered adding it back to the "XBlock API" page,
     but as noted in the class's new docstring, we do not want to encourage any new use of XBlockMixin.

--- a/xblock/__init__.py
+++ b/xblock/__init__.py
@@ -2,4 +2,4 @@
 XBlock Courseware Components
 """
 
-__version__ = '3.1.0'
+__version__ = '4.0.0'

--- a/xblock/fragment.py
+++ b/xblock/fragment.py
@@ -1,0 +1,25 @@
+"""
+Makes the Fragment class available through the old namespace location.
+"""
+import warnings
+
+import web_fragments.fragment
+
+
+class Fragment(web_fragments.fragment.Fragment):
+    """
+    A wrapper around web_fragments.fragment.Fragment that provides
+    backwards compatibility for the old location.
+    Deprecated.
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            'xblock.fragment is deprecated. Please use web_fragments.fragment instead',
+            DeprecationWarning,
+            stacklevel=2
+        )
+        super().__init__(*args, **kwargs)
+
+    # Provide older names for renamed methods
+    add_frag_resources = web_fragments.fragment.Fragment.add_fragment_resources
+    add_frags_resources = web_fragments.fragment.Fragment.add_resources

--- a/xblock/test/test_fragment.py
+++ b/xblock/test/test_fragment.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for the Fragment class.
+Note: this class has been deprecated in favor of web_fragments.fragment.Fragment
+"""
+from unittest import TestCase
+
+from xblock.fragment import Fragment
+
+
+class TestFragment(TestCase):
+    """
+    Unit tests for fragments.
+    """
+    def test_fragment(self):
+        """
+        Test the delegated Fragment class.
+        """
+        TEST_HTML = '<p>Hello, world!</p>'  # pylint: disable=invalid-name
+        fragment = Fragment()
+        fragment.add_content(TEST_HTML)
+        self.assertEqual(fragment.body_html(), TEST_HTML)


### PR DESCRIPTION
This fix: #680  
created issues in the following xblocks:

The following xblocks on edX need to be updated:
Oppia-xblock (currently archived and read only, https://github.com/edx/oppia-xblock )
schoolyourself (https://github.com/openedx/schoolyourself-xblock )
imagemodal (https://github.com/openedx/xblock-image-modal )
invideoquiz (https://github.com/openedx/xblock-in-video-quiz )
concept (https://github.com/openedx/ConceptXBlock )
audio (https://github.com/openedx/AudioXBlock )
animation (currently archived and ready only, https://github.com/openedx-unsupported/AnimationXBlock )

Therefore, rather than change all of these, we needed to expeditiously find a solution, which is reverting the depr in this case. The added pain of the passthrough is outweighed by the lift to play whack-a-mole on every xblock.