### PR TITLE
fix: Fix pypi error related to long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setup(
     name='XBlock',
     version=VERSION,
     description='XBlock Core Library',
+    long_description=open('README.rst').read(),
+    long_description_content_type='text/x-rst',
     packages=[
         'xblock',
         'xblock.django',


### PR DESCRIPTION
Fix pypi error related to long_description

``` shell
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         No content rendered from RST source.   
```

Error logs: https://github.com/openedx/XBlock/actions/runs/10089577081/job/27897375669#step:7:18

Fix reference: https://github.com/pypa/gh-action-pypi-publish/issues/162#issuecomment-1596104938