### PR TITLE
feat: XBlock overrides

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@ Unreleased
 5.1.0 - 2024-08-07
 ------------------
 
-* added ability to override an XBlock with the 'xblock.{version}.overrides' entry point.
+* added ability to override an XBlock with the 'xblock.v1.overrides' entry point
+* added ability to override an XBlock Aside with the 'xblock_asides.v1.overrides' entry point
 
 
 5.0.0 - 2024-05-30

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Change history for XBlock
 Unreleased
 ----------
 
+5.1.0 - 2024-08-07
+------------------
+
+* added ability to override an XBlock with the 'xblock.{version}.overrides' entry point.
+
+
 5.0.0 - 2024-05-30
 ------------------
 

--- a/docs/xblock-tutorial/edx_platform/index.rst
+++ b/docs/xblock-tutorial/edx_platform/index.rst
@@ -11,3 +11,4 @@ XBlocks and the edX Platform
    edx_lms
    devstack
    edx
+   overrides

--- a/docs/xblock-tutorial/edx_platform/overrides.rst
+++ b/docs/xblock-tutorial/edx_platform/overrides.rst
@@ -9,7 +9,7 @@ implementation.
 
 This can be done by:
 
-1. Creating an XBlock in a new or existing Django Plugin, installed into ``edx-platform``.
+1. Creating an XBlock in a new or existing package installed into ``edx-platform``.
 
 2. Adding the ``xblock.v1.overrides`` entry point in ``setup.py``, pointing to your
    custom XBlock.
@@ -28,8 +28,8 @@ Imagine there is an XBlock installed ``edx-platform``:
 
 .. code:: python
 
-    # edx-platform/xblocks/twitch_plays_pokemon.py
-    class TwitchPlaysPokemonBlock(XBlock):
+    # edx-platform/xblocks/video_block.py
+    class VideoBlock(XBlock):
     ...
 
     # edx-platform/setup.py
@@ -38,18 +38,18 @@ Imagine there is an XBlock installed ``edx-platform``:
 
         entry_points={
             "xblock.v1": [
-                "tpp = xblocks.twitch_plays_pokemon::TwitchPlaysPokemonBlock"
+                "video = xblocks.video_block::VideoBlock"
                 # ...
             ]
         }
     )
 
-If you then create your own Plugin App with a custom version of that XBlock...
+If you then create your own Python package with a custom version of that XBlock...
 
 .. code:: python
 
-    # your_plugin/xblocks/twitch_plays_pokemon.py
-    class YourTwitchPlaysPokemonBlock(XBlock):
+    # your_plugin/xblocks/video_block.py
+    class YourVideoBlock(XBlock):
     ...
 
     # your_plugin/setup.py
@@ -57,14 +57,14 @@ If you then create your own Plugin App with a custom version of that XBlock...
         # ...
         entry_points={
             "xblock.v1.overrides": [
-                "tpp = your_plugin.twitch_plays_pokemon::YourTwitchPlaysPokemonBlock"
+                "tpp = your_plugin.xblocks.video_block::YourVideoBlock"
                 # ...
             ],
         }
     )
 
-And install that app as a Django plugin, then your block should be loaded instead of the
-existing implementation.
+And install that package into your virtual environment, then your block should be
+loaded instead of the existing implementation.
 
 .. note::
 

--- a/docs/xblock-tutorial/edx_platform/overrides.rst
+++ b/docs/xblock-tutorial/edx_platform/overrides.rst
@@ -1,0 +1,75 @@
+.. _Replace a Preinstalled XBlock With a Custom Implementation:
+
+##########################################################
+Replace a Preinstalled XBlock With a Custom Implementation
+##########################################################
+
+In XBlock ``v5.1.0``, the ability was introduced to override an XBlock with a custom
+implementation.
+
+This can be done by:
+
+1. Creating an XBlock in a new or existing Django Plugin, installed into ``edx-platform``.
+
+2. Adding the ``xblock.v1.overrides`` entry point in ``setup.py``, pointing to your
+   custom XBlock.
+
+This works with updated logic in ``load_class``'s ``default_select``, which gives
+load priority to a class with the ``.overrides`` suffix.
+
+This can be disabled by providing a different ``select`` kwarg to ``load_class`` which
+ignores or otherwise changes override logic.
+
+*******
+Example
+*******
+
+Imagine there is an XBlock installed ``edx-platform``:
+
+.. code:: python
+
+    # edx-platform/xblocks/twitch_plays_pokemon.py
+    class TwitchPlaysPokemonBlock(XBlock):
+    ...
+
+    # edx-platform/setup.py
+    setup(
+        # ...
+
+        entry_points={
+            "xblock.v1": [
+                "tpp = xblocks.twitch_plays_pokemon::TwitchPlaysPokemonBlock"
+                # ...
+            ]
+        }
+    )
+
+If you then create your own Plugin App with a custom version of that XBlock...
+
+.. code:: python
+
+    # your_plugin/xblocks/twitch_plays_pokemon.py
+    class YourTwitchPlaysPokemonBlock(XBlock):
+    ...
+
+    # your_plugin/setup.py
+    setup(
+        # ...
+        entry_points={
+            "xblock.v1.overrides": [
+                "tpp = your_plugin.twitch_plays_pokemon::YourTwitchPlaysPokemonBlock"
+                # ...
+            ],
+        }
+    )
+
+And install that app as a Django plugin, then your block should be loaded instead of the
+existing implementation.
+
+.. note::
+
+    The ``load_class`` code will throw an error in the following cases:
+
+    1. There are multiple classes attempting to override one XBlock implementation.
+
+    2. There is an override provided where an existing XBlock implementation is not found.

--- a/docs/xblock-tutorial/edx_platform/overrides.rst
+++ b/docs/xblock-tutorial/edx_platform/overrides.rst
@@ -57,7 +57,7 @@ If you then create your own Python package with a custom version of that XBlock.
         # ...
         entry_points={
             "xblock.v1.overrides": [
-                "tpp = your_plugin.xblocks.video_block::YourVideoBlock"
+                "video = your_plugin.xblocks.video_block::YourVideoBlock"
                 # ...
             ],
         }

--- a/xblock/__init__.py
+++ b/xblock/__init__.py
@@ -2,4 +2,4 @@
 XBlock Courseware Components
 """
 
-__version__ = '5.0.0'
+__version__ = '5.1.0'

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -52,7 +52,7 @@ def select_with_overrides(identifier, all_entry_points):
     block_entry_points = []
 
     for block_entry_point in all_entry_points:
-        if block_entry_point.group.endswith('overrides'):
+        if block_entry_point.group.endswith('.overrides'):
             overrides.append(block_entry_point)
         else:
             block_entry_points.append(block_entry_point)

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -30,20 +30,9 @@ class AmbiguousPluginError(Exception):
 
 def default_select(identifier, all_entry_points):  # pylint: disable=inconsistent-return-statements
     """
-    Raise an exception when we have ambiguous entry points.
-    """
+    Select the appropriate entry point for a given block.
+    Honors the ability to override and take preference over the default entry point.
 
-    if len(all_entry_points) == 0:
-        raise PluginMissingError(identifier)
-    if len(all_entry_points) == 1:
-        return all_entry_points[0]
-    elif len(all_entry_points) > 1:
-        raise AmbiguousPluginError(all_entry_points)
-
-
-def select_with_overrides(identifier, all_entry_points):  # pylint: disable=inconsistent-return-statements
-    """
-    Return overridden entry point, if present. Otherwise returns entry point.
     Raise an exception when we have ambiguous entry points.
     """
 
@@ -60,13 +49,13 @@ def select_with_overrides(identifier, all_entry_points):  # pylint: disable=inco
     # Overrides get priority
     if len(overrides) == 1:
         return overrides[0]
-    if len(overrides) > 1:
+    elif len(overrides) > 1:
         raise AmbiguousPluginError(all_entry_points)
 
     # ... then default behavior
-    if len(block_entry_points) == 0:
+    elif len(block_entry_points) == 0:
         raise PluginMissingError(identifier)
-    if len(block_entry_points) == 1:
+    elif len(block_entry_points) == 1:
         return all_entry_points[0]
     elif len(block_entry_points) > 1:
         raise AmbiguousPluginError(all_entry_points)
@@ -129,7 +118,7 @@ class Plugin:
         if key not in PLUGIN_CACHE:
 
             if select is None:
-                select = select_with_overrides
+                select = default_select
 
             all_entry_points = [
                 *importlib.metadata.entry_points(group=f'{cls.entry_point}.overrides', name=identifier),

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -41,7 +41,7 @@ def default_select(identifier, all_entry_points):  # pylint: disable=inconsisten
     block_entry_points = []
 
     for block_entry_point in all_entry_points:
-        if "overrides" in block_entry_point.group:
+        if block_entry_point.group.endswith('overrides'):
             overrides.append(block_entry_point)
         else:
             block_entry_points.append(block_entry_point)

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -28,6 +28,10 @@ class AmbiguousPluginError(Exception):
         super().__init__(msg)
 
 
+class AmbiguousPluginOverrideError(AmbiguousPluginError):
+    """Raised when a class name produces more than one override for an entry_point."""
+
+
 def _default_select_no_override(identifier, all_entry_points):  # pylint: disable=inconsistent-return-statements
     """
     Selects plugin for the given identifier, raising on error:
@@ -72,7 +76,7 @@ def default_select(identifier, all_entry_points):
     if len(overrides) == 1:
         return overrides[0]
     elif len(overrides) > 1:
-        raise AmbiguousPluginError(all_entry_points)
+        raise AmbiguousPluginOverrideError(overrides)
     return default_plugin
 
 

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -30,7 +30,11 @@ class AmbiguousPluginError(Exception):
 
 def _default_select_no_override(identifier, all_entry_points):  # pylint: disable=inconsistent-return-statements
     """
-    Raise an exception when we have ambiguous entry points.
+    Selects plugin for the given identifier, raising on error:
+
+    Raises:
+    - PluginMissingError when we don't have an entry point.
+    - AmbiguousPluginError when we have ambiguous entry points.
     """
 
     if len(all_entry_points) == 0:
@@ -43,8 +47,12 @@ def _default_select_no_override(identifier, all_entry_points):  # pylint: disabl
 
 def default_select(identifier, all_entry_points):
     """
-    Honors the ability for an XBlock to override the default entry point.
-    Raise an exception when we have ambiguous entry points.
+    Selects plugin for the given identifier with the ability for a Plugin to override
+    the default entry point.
+
+    Raises:
+    - PluginMissingError when we don't have an entry point or entry point to override.
+    - AmbiguousPluginError when we have ambiguous entry points.
     """
 
     # Split entry points into overrides and non-overrides
@@ -102,12 +110,20 @@ class Plugin:
     def load_class(cls, identifier, default=None, select=None):
         """Load a single class specified by identifier.
 
-        If `identifier` specifies more than a single class, and `select` is not None,
-        then call `select` on the list of entry_points. Otherwise, choose
-        the first one and log a warning.
+        By default, this returns the class mapped to `identifier` from entry_points
+        matching `{cls.entry_points}.overrides` or `{cls.entry_points}`, in that order.
 
-        If `default` is provided, return it if no entry_point matching
-        `identifier` is found. Otherwise, will raise a PluginMissingError
+        If multiple classes are found for either `{cls.entry_points}.overrides` or
+        `{cls.entry_points}`, it will raise an `AmbiguousPluginError`.
+
+        If no classes are found for `{cls.entry_points}`, it will raise a `PluginMissingError`.
+
+        Args:
+        - identifier: The class to match on.
+
+        Kwargs:
+        - default: A class to return if no entry_point matching `identifier` is found.
+        - select: A function to override our default_select functionality.
 
         If `select` is provided, it should be a callable of the form::
 

--- a/xblock/test/test_plugin.py
+++ b/xblock/test/test_plugin.py
@@ -57,14 +57,8 @@ def test_ambiguous_plugins():
 
 
 @XBlock.register_temp_plugin(OverriddenBlock, "overridden_block", group='xblock.v1.overrides')
-@XBlock.register_temp_plugin(AmbiguousBlock1, "overridden_block")
-@XBlock.register_temp_plugin(AmbiguousBlock2, "overridden_block")
-@XBlock.register_temp_plugin(UnambiguousBlock, "good_block")
+@XBlock.register_temp_plugin(UnambiguousBlock, "overridden_block")
 def test_plugin_override():
-    # We can load ok blocks even if there are bad blocks.
-    cls = XBlock.load_class("good_block")
-    assert cls is UnambiguousBlock
-
     # Trying to load a block that is overridden returns the correct override
     override = XBlock.load_class("overridden_block")
     assert override is OverriddenBlock

--- a/xblock/test/test_plugin.py
+++ b/xblock/test/test_plugin.py
@@ -6,7 +6,7 @@ import pytest
 
 from xblock.core import XBlock
 from xblock import plugin
-from xblock.plugin import AmbiguousPluginError, PluginMissingError
+from xblock.plugin import AmbiguousPluginError, AmbiguousPluginOverrideError, PluginMissingError
 
 
 class AmbiguousBlock1(XBlock):
@@ -82,7 +82,7 @@ def test_plugin_override_ambiguous():
         "xblock.test.test_plugin.AmbiguousBlock1, "
         "xblock.test.test_plugin.AmbiguousBlock2"
     )
-    with pytest.raises(AmbiguousPluginError, match=expected_msg):
+    with pytest.raises(AmbiguousPluginOverrideError, match=expected_msg):
         XBlock.load_class("overridden_block")
 
 

--- a/xblock/test/test_plugin.py
+++ b/xblock/test/test_plugin.py
@@ -64,6 +64,13 @@ def test_plugin_override():
     assert override is OverriddenBlock
 
 
+@XBlock.register_temp_plugin(OverriddenBlock, "overridden_block", group='xblock.v1.overrides')
+def test_plugin_override_missing_original():
+    # Trying to override a block that has no original block should raise an error
+    with pytest.raises(PluginMissingError, match="overridden_block"):
+        XBlock.load_class("overridden_block")
+
+
 @XBlock.register_temp_plugin(AmbiguousBlock1, "overridden_block", group='xblock.v1.overrides')
 @XBlock.register_temp_plugin(AmbiguousBlock2, "overridden_block", group='xblock.v1.overrides')
 @XBlock.register_temp_plugin(OverriddenBlock, "overridden_block")


### PR DESCRIPTION
Add ability to override another XBlock with the `xblock.v1.overrides` entrypoint. 

## Notes

- Fixes #777 which removed our current hack for overriding existing XBlock behavior with a plugin.
- See [conversation here](https://discuss.openedx.org/t/override-default-edx-platform-xblock-mappings-without-forking/12441/) for historical context & reasoning.

## Usage

``` python
setup(
    # ...
    entry_points={
        "xblock.v1.overrides": [
            "html = my_new_repo.my_new_block:HtmlBlock",
            "problem = my_new_repo.my_new_block:ProblemBlock",
            "video = my_new_repo.my_new_block:VideoBlock",
        ],
    }
)
```

## Tests

- [x] Unit tests
- [x] Smoke tests in LMS
  - [x] Overridden block types work as expected
  - [x] Non-overridden block types work as expected
- [x] Tests in Studio
  - [x] Overridden block types work as expected
  - [x] Non-overridden block types work as expected
- [x] Import tests
  - [x] Overridden block types work as expected
  - [x] Non-overridden block types work as expected
- [x] Export tests
  - [x] Overridden block types work as expected
  - [x] Non-overridden block types work as expected
- [ ] Other????