### PR TITLE
perf: cache missing XBlock mappings in load_class

### DIFF
--- a/xblock/__init__.py
+++ b/xblock/__init__.py
@@ -2,4 +2,4 @@
 XBlock Courseware Components
 """
 
-__version__ = '5.1.0'
+__version__ = '5.1.1'


### PR DESCRIPTION
Checking the entrypoints for the XBlock class we want for a given tag name is relatively expensive. We mitigate this by caching the mapping of tags to classes in Plugin.load_class(). But before this commit, we weren't caching failed lookups, i.e. the situation where there is no XBlock that maps to a given tag. This meant that if a course had many instances of a type of XBlock that is not installed on the given server, we would be constantly scanning entrypoints to look for our non-existent XBlock subclass. This really slows down things like the Studio course outline page.

The fix here is to store failed lookups as None values in the PLUGIN_CACHE.