### PR TITLE
fix: throw an error if the scope if None on scope_mappings [FC-0076]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change history for XBlock
 Unreleased
 ----------
 
+5.1.2 - 2025-02-07
+------------------
+
+* throws InvalidScopeError if the scope is not defined
+
 5.1.0 - 2024-08-07
 ------------------
 

--- a/xblock/__init__.py
+++ b/xblock/__init__.py
@@ -2,4 +2,4 @@
 XBlock Courseware Components
 """
 
-__version__ = '5.1.1'
+__version__ = '5.1.2'

--- a/xblock/field_data.py
+++ b/xblock/field_data.py
@@ -145,10 +145,12 @@ class SplitFieldData(FieldData):
         """Return the field data for the field `name` on the :class:`~xblock.core.XBlock` `block`"""
         scope = block.fields[name].scope
 
-        if scope not in self._scope_mappings:
+        scope_mapping = self._scope_mappings.get(scope)
+
+        if scope_mapping is None:
             raise InvalidScopeError(scope)
 
-        return self._scope_mappings[scope]
+        return scope_mapping
 
     def get(self, block, name):
         return self._field_data(block, name).get(block, name)

--- a/xblock/test/test_field_data.py
+++ b/xblock/test/test_field_data.py
@@ -40,6 +40,11 @@ class TestSplitFieldData:
             Scope.content: self.content,
             Scope.settings: self.settings
         })
+        self.split_empty = SplitFieldData({
+            Scope.content: self.content,
+            Scope.settings: self.settings,
+            Scope.user_state: None,
+        })
         self.runtime = TestRuntime(services={'field-data': self.split})
         self.block = TestingBlock(
             runtime=self.runtime,
@@ -75,6 +80,10 @@ class TestSplitFieldData:
     def test_invalid_scope(self):
         with pytest.raises(InvalidScopeError):
             self.split.get(self.block, 'user_state')
+
+    def test_empty_scope(self):
+        with pytest.raises(InvalidScopeError):
+            self.split_empty.get(self.block, 'user_state')
 
     def test_default(self):
         self.split.default(self.block, 'content')


### PR DESCRIPTION
## Description

While using the XBlock API, we may not have a `FieldSet` for a specific scope, which resulted in `AttributeError: 'NoneType' object has no attribute 'foo'` errors.

With this PR, the `InvalidScopeError` is now thrown in these cases.

## Testing instructions
- Edit a `Survey` block on the Library Authoring page and check the error below (before https://github.com/openedx/edx-platform/pull/36226)

```
cms-1          | 2025-01-28 19:36:18,402 ERROR 2163 [celery_utils.logged_task] [user 4] [ip 172.18.0.1] logged_task.py:48 - [9d7cda4b-afd2-404f-a39c-7a185c486907] failed due to Traceback (most recent call last):
cms-1          |   File "/openedx/venv/lib/python3.11/site-packages/celery/app/trace.py", line 453, in trace_task
cms-1          |     R = retval = fun(*args, **kwargs)
cms-1          |                  ^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/openedx/venv/lib/python3.11/site-packages/celery/app/autoretry.py", line 38, in run
cms-1          |     return task._orig_run(*args, **kwargs)
cms-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/openedx/venv/lib/python3.11/site-packages/edx_django_utils/monitoring/internal/code_owner/utils.py", line 195, in new_function
cms-1          |     return wrapped_function(*args, **kwargs)
cms-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/tasks.py", line 57, in upsert_library_block_index_doc
cms-1          |     api.upsert_library_block_index_doc(usage_key)
cms-1          |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/api.py", line 639, in upsert_library_block_index_doc
cms-1          |     searchable_doc_for_library_block(library_block_metadata)
cms-1          |   File "/openedx/edx-platform/openedx/core/djangoapps/content/search/documents.py", line 381, in searchable_doc_for_library_block
cms-1          |     block = xblock_api.load_block(xblock_metadata.usage_key, user=None)
cms-1          |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/openedx/edx-platform/openedx/core/djangoapps/xblock/api.py", line 117, in load_block
cms-1          |     return runtime.get_block(usage_key, version=version)
cms-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/openedx/edx-platform/openedx/core/djangoapps/xblock/runtime/learning_core_runtime.py", line 229, in get_block
cms-1          |     block.force_save_fields(block._get_fields_to_save())  # pylint: disable=protected-access
cms-1          |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cms-1          |   File "/mnt/xblock/xblock/core.py", line 531, in force_save_fields
cms-1          |     self._field_data.set_many(self, fields_to_save_json)
cms-1          |   File "/mnt/xblock/xblock/field_data.py", line 164, in set_many
cms-1          |     field_data.set_many(block, new_update_dict)
cms-1          |     ^^^^^^^^^^^^^^^^^^^
cms-1          | AttributeError: 'NoneType' object has no attribute 'set_many'
```
- Checkout the current PR and mount it on your tutor stack
- Check that the error throw now is the correct `InvalidScopeError`

___
Private ref: [FAL-4033](https://tasks.opencraft.com/browse/FAL-4033)