### PR TITLE
docs: Update edx.rtd.io links to docs.openedx.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,11 +226,11 @@ Please do not report security issues in public. Please email security@openedx.or
     :alt: Codecov
 
 .. |doc-badge| image:: https://readthedocs.org/projects/XBlock/badge/?version=latest
-    :target: https://edx.readthedocs.io/projects/xblock/en/latest/
+    :target: https://docs.openedx.org/projects/xblock/en/latest/
     :alt: Documentation
 
 .. |pyversions-badge| image:: https://img.shields.io/pypi/pyversions/XBlock.svg
-    :target: https://edx.readthedocs.io/projects/xblock/en/latest/
+    :target: https://docs.openedx.org/projects/xblock/en/latest/
     :alt: Supported Python versions
 
 .. |license-badge| image:: https://img.shields.io/github/license/openedx/XBlock.svg

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,10 +9,10 @@ metadata:
   name: 'XBlock'
   description: "Framework for building custom learning components that run in the Open edX LMS!"
   links:
-    - url: "https://xblock.readthedocs.org"
+    - url: "https://docs.openedx.org/projects/xblock/en/latest/"
       title: "XBlock Docs"
       icon: "LocalLibrary"
-    - url: "https://edx.readthedocs.io/projects/xblock-tutorial/en/latest/overview/introduction.html"
+    - url: "https://docs.openedx.org/projects/xblock/en/latest/xblock-tutorial/index.html"
       title: "XBlock Tutorial"
       # Backstage uses the MaterialUI Icon Set.
       # https://mui.com/material-ui/material-icons/

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -55,16 +55,16 @@
 
 .. _thumbs.css: https://github.com/openedx/xblock-sdk/blob/master/sample_xblocks/thumbs/static/css/thumbs.css
 
-.. _Google Drive file tool: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/google_docs.html
+.. _Google Drive file tool: https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/add_google_drive.html
 
-.. _Open Response Assessments: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/open_response_assessments/OpenResponseAssessments.html
+.. _Open Response Assessments: https://docs.openedx.org/en/latest/educators/concepts/exercise_tools/OpenResponseAssessments.html
 
-.. _Google calendar tool: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/google_calendar.html
+.. _Google calendar tool: https://docs.openedx.org/en/latest/educators/how-tos/course_development/exercise_tools/embed_google_calendar.html
 
-.. _Finding the Usage ID for Course Content: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/lti/lti_address_content.html#finding-the-usage-id-for-course-content
+.. _Finding the Usage ID for Course Content: https://docs.openedx.org/en/latest/educators/how-tos/advanced_features/lti_determine_content_address.html#finding-the-usage-id-for-course-content
 
 .. _Installing, Configuring, and Running the Open edX Platform: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/index.html
 
-.. _Developing Course Components: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/developing_course/course_components.html
+.. _Developing Course Components: https://docs.openedx.org/en/latest/educators/references/course_development/what_is_a_component.html
 
 .. _HTML unicode characters: https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references

--- a/docs/xblock-tutorial/concepts/runtimes.rst
+++ b/docs/xblock-tutorial/concepts/runtimes.rst
@@ -231,6 +231,5 @@ For courses created prior to October 2014, the ``usage_id`` begins with
 ``https://courses.edx.org/xblock/i4x://edX/DemoX.1/problem/47bf6dbce8374b789e3ebdefd74db332``
 
 
-.. TODO Update this URL once docs move to docs.openedx.org
-.. _XBlock Runtime API: http://edx.readthedocs.io/projects/xblock/en/latest/
+.. _XBlock Runtime API: https://docs.openedx.org/projects/xblock/en/latest/
 .. include:: ../../links.rst


### PR DESCRIPTION
Convert links from edx.readthedocs.io to links on docs.openedx.org

The installing & configuring guide is not yet moved, so those links are currently unchanged. Ref https://github.com/openedx/docs.openedx.org/issues/830
