### PR TITLE
docs: Update an intersphinx link after an upstream update.

### DIFF
--- a/docs/xblock-tutorial/glossary.rst
+++ b/docs/xblock-tutorial/glossary.rst
@@ -2,4 +2,4 @@
 Open edX Glossary
 #################
 
-:doc:`docs-openedx-org:developers/references/glossary`
+:doc:`docs-openedx-org:glossary`


### PR DESCRIPTION
We migrated docs.openedx.org to have one unified glossary.
