### PR TITLE
Update intersphinx link (Sumac backport)

### DIFF
--- a/docs/xblock-tutorial/glossary.rst
+++ b/docs/xblock-tutorial/glossary.rst
@@ -2,4 +2,4 @@
 Open edX Glossary
 #################
 
-:doc:`docs-openedx-org:developers/references/glossary`
+:doc:`docs-openedx-org:glossary`


### PR DESCRIPTION
Sumac docs are failing to build due to this issue. Backport to Sumac. Ref #825 

![image](https://github.com/user-attachments/assets/d9202d29-0483-48ce-ab6a-1e1b332fc64f)
