### PR TITLE
build: Untag this repo for release

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,7 +24,6 @@ metadata:
     # names that might be interested in changes to the architecture of this
     # component.
     openedx.org/arch-interest-groups: "feanil"
-    openedx.org/release: master
 spec:
 
   # (Required) This can be a group (`group:<github_group_name>`) or a user (`user:<github_username>`).


### PR DESCRIPTION
This repo was previously tagged for release only to facilitate docs builds. As it is a transitive dependency, it should not be tagged for release. Please see openedx/docs.openedx.org#941 for more detail.
