### PR TITLE
Add support for Django 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11', '3.12']
-        toxenv: [quality, django42]
+        toxenv: [quality, django42, django52]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change history for XBlock
 Unreleased
 ----------
 
+5.2.0 - 2025-04-08
+------------------
+
+* Added support for Django 5.2
+
 5.1.2 - 2025-02-07
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,312}-django{42}, quality, docs
+envlist = py{311,312}-django{42,52}, quality, docs
 
 [pytest]
 DJANGO_SETTINGS_MODULE = xblock.test.settings
@@ -10,6 +10,7 @@ norecursedirs = .* docs requirements
 [testenv]
 deps =
     django42: Django>=4.2,<5.0
+    django52: Django>=5.2,<6.0
     -r requirements/test.txt
 changedir = {envsitepackagesdir}
 commands =
@@ -33,6 +34,7 @@ commands =
 [testenv:quality]
 deps =
     django42: Django>=4.2,<5.0
+    django52: Django>=5.2,<6.0
     -r requirements/test.txt
 changedir = {toxinidir}
 commands =

--- a/xblock/__init__.py
+++ b/xblock/__init__.py
@@ -2,4 +2,4 @@
 XBlock Courseware Components
 """
 
-__version__ = '5.1.2'
+__version__ = '5.2.0'

--- a/xblock/test/settings.py
+++ b/xblock/test/settings.py
@@ -40,10 +40,6 @@ SITE_ID = 1
 # to load the internationalization machinery.
 USE_I18N = True
 
-# If you set this to False, Django will not format dates, numbers and
-# calendars according to the current locale.
-USE_L10N = True
-
 # If you set this to False, Django will not use timezone-aware datetimes.
 USE_TZ = True
 


### PR DESCRIPTION
- Resolves https://github.com/openedx/XBlock/issues/832

### Changes
[The USE_L10N setting will be removed](https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-5-0).