### PR TITLE
docs: Add internal ref to XBlock Intro doc

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,4 +1,4 @@
-.. _Introduction to XBlocks:
+.. _XBlock Concepts:
 
 #######################
 Introduction to XBlocks

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,3 +1,5 @@
+.. _Introduction to XBlocks:
+
 #######################
 Introduction to XBlocks
 #######################


### PR DESCRIPTION
Small change - so I can cross-reference docs